### PR TITLE
Use inline format parameters

### DIFF
--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -46,9 +46,11 @@ impl Action for AddIndex {
             .map(|column| format!("\"{}\"", column.real_name))
             .collect();
 
-        let unique = if self.index.unique { "UNIQUE" } else { "" };
         let index_type_def = if let Some(index_type) = &self.index.index_type {
-            format!("USING {index_type}")
+            format!(
+                "USING {index_type}",
+                index_type = index_type,
+            )
         } else {
             "".to_string()
         };
@@ -60,6 +62,8 @@ impl Action for AddIndex {
             name = self.index.name,
             table = self.table,
             columns = column_real_names.join(", "),
+            unique = if self.index.unique { "UNIQUE" } else { "" },
+            index_type_def = index_type_def,
         ))
         .context("failed to create index")?;
         Ok(())

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -169,8 +169,6 @@ impl Action for AlterColumn {
                 .collect();
             let temp_index_name = self.temp_index_name(ctx, index.oid);
 
-            let unique_def = if index.unique { "UNIQUE" } else { "" };
-
             db.query(&format!(
                 r#"
                 CREATE {unique_def} INDEX CONCURRENTLY IF NOT EXISTS "{new_index_name}" ON "{table}" USING {index_type} ({columns})
@@ -179,6 +177,7 @@ impl Action for AlterColumn {
                 table = table.real_name,
                 columns = index_columns.join(", "),
                 index_type = index.index_type,
+                unique_def = if index.unique { "UNIQUE" } else { "" },
             ))
             .context("failed to create temporary index")?;
         }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -224,9 +224,12 @@ fn add_spacer(text: &str, char: &str) -> String {
         .take(num_of_chars)
         .collect::<String>();
 
-    let extra = if text.len() % 2 == 0 { "" } else { char };
-
-    format!("{spacer} {text} {spacer}{extra}", spacer = spacer)
+    format!(
+        "{spacer} {text} {spacer}{extra}",
+        spacer = spacer,
+        extra = if text.len() % 2 == 0 { "" } else { char },
+        text = text,
+    )
 }
 
 pub fn assert_cleaned_up(db: &mut Client) {


### PR DESCRIPTION
I am trying out your tool and compiled on my machine (Manjaro 21.2.1, Rustc 1.56.1), but I got the following errors

```
error: there is no argument named `unique_def`
   --> src/migrations/alter_column.rs:176:24
    |
176 |                 CREATE {unique_def} INDEX CONCURRENTLY IF NOT EXISTS "{new_index_name}" ON "{table}" USING {index_type} ({columns})
```

This happened with both `cargo install reshape` (outside the git repository) and `cargo build` inside the cloned repository. I have done the world's tiniest amount of rust so this could be a lack of knowledge on my part. In this PR, I just inline the parameters that were being complained about. Please let me know if this is useful or I am just doing something wrong. I really appreciate the help. Thanks!