### PR TITLE
Minor correction to url environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ The options below can be used with all commands that communicate with Postgres. 
 
 | Option | Default | Description |
 | ------ | ------- | ----------- |
-| `--url`  | | URI to connect to your Postgres database.<br>Can also be provided with the environment variable `DATABASE_URL`. |
+| `--url`  | | URI to connect to your Postgres database.<br>Can also be provided with the environment variable `POSTGRES_URL`. |
 | `--host` | `localhost` | Hostname to use when connecting to Postgres |
 | `--port` | `5432` | Port which Postgres is listening on |
 | `--database` | `postgres` | Database name |


### PR DESCRIPTION
I noticed this here: https://github.com/fabianlindfors/reshape/blob/ef6fe6491859a62cbd1474341cf2c4112da2eca4/src/main.rs#L105