### PR TITLE
Use nullable field from changes

### DIFF
--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -187,7 +187,7 @@ impl Action for AlterColumn {
         // This constraint is set as NOT VALID so it doesn't apply to existing rows and
         // the existing rows don't need to be scanned under an exclusive lock.
         // Thanks to this, we can set the full column as NOT NULL later with minimal locking.
-        if !column.nullable {
+        if !self.changes.nullable.unwrap_or(true) {
             let query = format!(
                 r#"
                 ALTER TABLE "{table}"


### PR DESCRIPTION
This text is broken up into two pieces. The first is the context for the fix (which I think is correct) and the second is a question because I am misunderstanding something. I also want to try to add some tests for this.

Fix
---

I wanted a migration that adds a `NOT NULL` constraint to an existing field. You can see the example file in the question section below. This didn't work. After a little print debugging I realized that the `column.nullable` meant the existing column which would retain its' nullability always. You could never remove or add it with the TOML. I am pretty sure this works for adding or removing a nullability constraint but I want to write some tests which I'll do soon!

Question
---

The next issue I faced is given the following migration,

```toml
[[actions]]
type = "alter_column"
table = "users"
column = "name"

  [actions.changes]
  nullable = false
```

After `reshape migrate`, I am unable to add new rows to the schema. I am a bit out of my element here and still learning, but I tried the following,

```sql
insert into migration_5_make_name_not_null.users (name) values ('chiroptical');
```

which yields,

```txt
null value in column "name" of relation "users" violates not-null constraint
DETAIL:  Failing row contains (8, null, null).
```

I am a bit confused here. Am I supposed to only insert data into the public schema and let the triggers handle everything else?
How does this work with `SET search_path TO migration_5_make_name_not_null`? Maybe I need to read more postgresql documentation here and I shouldn't be asking you?