### PR TITLE
Output the failing filename when showing a parse error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::{
     path::Path,
 };
 
+use anyhow::{Context};
 use clap::{Args, Parser};
 use reshape::{
     migrations::{Action, Migration},
@@ -211,7 +212,8 @@ fn find_migrations(opts: &FindMigrationsOptions) -> anyhow::Result<Vec<Migration
         .map(|result| {
             result.and_then(|(path, data)| {
                 let extension = path.extension().and_then(|ext| ext.to_str()).unwrap();
-                let file_migration = decode_migration_file(&data, extension)?;
+                let file_migration = decode_migration_file(&data, extension)
+                    .with_context(|| format!("failed to parse migration file {}", path.display()))?;
 
                 let file_name = path.file_stem().and_then(|name| name.to_str()).unwrap();
                 Ok(Migration {


### PR DESCRIPTION
I'll admit I don't know Rust, hope this is a reasonable way to do this.

Before:

```
Error: missing field `name` for key `actions` at line 6 column 3
```

After:

```
Error: failed to parse migration file migrations/10_a.toml

Caused by:
    missing field `name` for key `actions` at line 6 column 3
```