### PR TITLE
Fix incorrect example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The `add_index` action will add a new index to an existing table.
 ```toml
 [[actions]]
 type = "create_table"
-table = "users"
+name = "users"
 primary_key = "id"
 
 	[[actions.columns]]


### PR DESCRIPTION
Unrelated to this PR: I'm not sure if you're looking for some general feedback. Here are three things I've noticed in my not-very-serious usage of this.

1) As far as I can tell the filenames are lexically sorted. So if you have 10 migrations (`1_blah`, `2_blah`, ..., `10_blah`) then the order Reshape will process them in is `10_blah`, `1_blah`, `2_blah`.... I found this quite unexpected and undesirable. Not sure if this is a documentation bug (the README suggests this format) or a bug bug. Personally, I think it's worth enforcing the filename format so you can sort numerically on the number.
2) During development I've been preferring to blow away my entire database and update migration 1_ rather than creating tons of additional migrations. I think the reason I am doing this is because I was originally creating development migrations in the same style as I make Git commits: frequently and without thought. But whereas I can rewrite history and squash everything with Git when I want to PR, I have no automatic ability to squash my development migrations into one final migration when I am ready to PR my schema. And maybe it wouldn't be so bad if it were like Git commits where few people ever look at the history, but I look at these migration files to understand the current schema so I'm incentivized to keep the files tidy.
3) Blowing away my database has generally been fine, but I now find myself in the position of (even during development) needing tables within the same database that I keep around for a long time (these tables store elevation data and are expensive to compute) along with tables that (due to previous problem) I prefer to blow away. I am not sure if repairing a database with missing tables is even a usecase you're interested in, but if I can't doctor/repair the database back to what Reshape wants it to be this may ultimately force me off Reshape.