### PR TITLE
Fix syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,8 +556,8 @@ start = """
 """
 
 abort = """
-	DROP EXTENSION IF NOT EXISTS postgis;
-	DROP EXTENSION IF NOT EXISTS pg_stat_statements;
+	DROP EXTENSION IF EXISTS postgis;
+	DROP EXTENSION IF EXISTS pg_stat_statements;
 """
 ```
 


### PR DESCRIPTION
Telling Postgres to only drop an extension if it isn't installed made it sad

(PS I only noticed this because I am trying to use your suggested `migration start/abort` development workflow. I think you're correct but I don't have enough practice to have feedback. Sorry for going silent on the other bug!)