### PR TITLE
Add support for PARTITION BY and non-concurrent indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ primary_key = ["id"]
 	referenced_columns = ["id"]
 ```
 
+*Example: create `users` with a partition*
+
+```toml
+[[actions]]
+type = "create_table"
+name = "users"
+primary_key = ["id"]
+
+	[[actions.columns]]
+	name = "id"
+	type = "INTEGER"
+
+	[actions.partition_by]
+	hash = ["id"] # or list = ["id"] or range = ["id"]
+```
+
 #### Rename table
 
 The `rename_table` action will change the name of an existing table.
@@ -493,6 +509,19 @@ table = "products"
 
 	# One of: btree (default), hash, gist, spgist, gin, brin
 	type = "gin"
+```
+
+*Example: add a non-concurrent index
+
+```toml
+[[actions]]
+type = "add_index"
+table = "products"
+
+	[actions.index]
+	name = "data_idx"
+	columns = ["data"]
+	concurrently = false
 ```
 
 #### Remove index


### PR DESCRIPTION
I made a choice to do `list = ["id"]` instead of `list = "id"` even though Postgres only allows single column LIST partitions (as opposed to multi-column hash and range partitions.) The Postgres syntax in this case is `('id')` and the expr is `(column [, ...])` anyway so I felt this was the least confusing thing to do.