### PR TITLE
Adds reference to Go helper library

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Reshape relies on your application using a specific schema. When establishing th
 - [Rust](https://github.com/fabianlindfors/reshape-helper)
 - [Ruby (and Rails)](https://github.com/fabianlindfors/reshape-ruby)
 - [Python (and Django)](https://github.com/fabianlindfors/reshape-python)
+- [Go](https://github.com/leourbina/reshape-helper)
 
 If your application is not using one of the languages with an available helper library, you can instead generate the query with the command: `reshape schema-query`. To pass it along to your application, you can for example use an environment variable in your run script: `RESHAPE_SCHEMA_QUERY=$(reshape schema-query)`. Then in your application:
 


### PR DESCRIPTION
Hey, just added a very straightforward port of the helper library to Go. You can find it here: https://github.com/leourbina/reshape-helper. 

I'm still in the process of starting to use it on a Go side project, but so far pretty intrigued by what Reshape offers. 