### PR TITLE
Removed an unwrap that made a panic on migration files without extensions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,13 @@ fn find_migrations(opts: &FindMigrationsOptions) -> anyhow::Result<Vec<Migration
         })
         .map(|result| {
             result.and_then(|(path, data)| {
-                let extension = path.extension().and_then(|ext| ext.to_str()).unwrap();
+                let extension = path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("migration file {} missing extension", path.display())
+                    })?;
+
                 let file_migration =
                     decode_migration_file(&data, extension).with_context(|| {
                         format!("failed to parse migration file {}", path.display())


### PR DESCRIPTION
When running ` reshape migration start` I had a panic because my file didn't have an extension. No big deal.

```
thread 'main' panicked at src/main.rs:220:79:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Added a `ok_or_else` for the file.