### PR TITLE
Add ON DELETE and ON UPDATE support for foreign keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ primary_key = ["id"]
 	columns = ["user_id"]
 	referenced_table = "users"
 	referenced_columns = ["id"]
+
+	# Optional, one of: NO ACTION (default), RESTRICT, CASCADE, SET NULL, SET DEFAULT
+	on_delete = "CASCADE"
+	on_update = "CASCADE"
 ```
 
 _Example: create `profiles` table based on existing `users` table_
@@ -300,6 +304,10 @@ table = "items"
 	columns = ["user_id"]
 	referenced_table = "users"
 	referenced_columns = ["id"]
+
+	# Optional, one of: NO ACTION (default), RESTRICT, CASCADE, SET NULL, SET DEFAULT
+	on_delete = "CASCADE"
+	on_update = "CASCADE"
 ```
 
 #### Remove foreign key

--- a/src/docs/actions/add-foreign-key.md
+++ b/src/docs/actions/add-foreign-key.md
@@ -13,6 +13,8 @@ table = "table_name"          # Required: table to add FK to
     columns = ["col1"]
     referenced_table = "other_table"
     referenced_columns = ["id"]
+    on_delete = "CASCADE"     # Optional: referential action on delete
+    on_update = "CASCADE"     # Optional: referential action on update
 ```
 
 ## Fields
@@ -23,6 +25,14 @@ table = "table_name"          # Required: table to add FK to
 | `foreign_key.columns` | array | Yes | Columns in this table |
 | `foreign_key.referenced_table` | string | Yes | Referenced table |
 | `foreign_key.referenced_columns` | array | Yes | Referenced columns |
+| `foreign_key.on_delete` | string | No | Referential action when the referenced row is deleted |
+| `foreign_key.on_update` | string | No | Referential action when the referenced row is updated |
+
+### Referential Actions
+
+`on_delete` and `on_update` accept the same keywords as Postgres, in upper or lower case:
+`NO ACTION` (default), `RESTRICT`, `CASCADE`, `SET NULL` and `SET DEFAULT`. Any other value
+is rejected when the migration file is parsed.
 
 ## Examples
 
@@ -52,6 +62,20 @@ table = "order_items"
     referenced_columns = ["order_id", "product_id"]
 ```
 
+### Foreign Key with Cascading Delete
+
+```toml
+[[actions]]
+type = "add_foreign_key"
+table = "posts"
+
+    [actions.foreign_key]
+    columns = ["user_id"]
+    referenced_table = "users"
+    referenced_columns = ["id"]
+    on_delete = "CASCADE"
+```
+
 ## Behavior
 
 1. **Start phase**:
@@ -67,3 +91,4 @@ table = "order_items"
 - Existing data is validated after creation
 - The foreign key is enforced immediately for new inserts/updates
 - Constraint name follows pattern: `{table}_{columns}_fkey`
+- Referential actions default to `NO ACTION` when not specified

--- a/src/docs/actions/create-table.md
+++ b/src/docs/actions/create-table.md
@@ -21,6 +21,8 @@ primary_key = ["id"]          # Required: primary key column(s)
     columns = ["col"]
     referenced_table = "other"
     referenced_columns = ["id"]
+    on_delete = "CASCADE"     # Optional: referential action on delete
+    on_update = "CASCADE"     # Optional: referential action on update
 
     [actions.up]              # Optional: populate from existing table
     table = "source_table"
@@ -37,6 +39,20 @@ primary_key = ["id"]          # Required: primary key column(s)
 | `nullable` | boolean | No | Allow NULL values (default: true) |
 | `default` | string | No | SQL expression for default value |
 | `generated` | string | No | Generation clause (e.g., "ALWAYS AS IDENTITY") |
+
+## Foreign Key Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `columns` | array | Yes | Columns in this table |
+| `referenced_table` | string | Yes | Referenced table |
+| `referenced_columns` | array | Yes | Referenced columns |
+| `on_delete` | string | No | Referential action when the referenced row is deleted |
+| `on_update` | string | No | Referential action when the referenced row is updated |
+
+`on_delete` and `on_update` accept the same keywords as Postgres, in upper or lower case:
+`NO ACTION` (default), `RESTRICT`, `CASCADE`, `SET NULL` and `SET DEFAULT`. Any other value
+is rejected when the migration file is parsed.
 
 ## Examples
 
@@ -90,6 +106,9 @@ primary_key = ["id"]
     columns = ["user_id"]
     referenced_table = "users"
     referenced_columns = ["id"]
+
+    # Delete the posts when their user is deleted
+    on_delete = "CASCADE"
 ```
 
 ### Table with Data Migration

--- a/src/migrations/add_foreign_key.rs
+++ b/src/migrations/add_foreign_key.rs
@@ -49,6 +49,7 @@ impl Action for AddForeignKey {
             ADD CONSTRAINT {constraint_name}
             FOREIGN KEY ({columns})
             REFERENCES "{referenced_table}" ({referenced_columns})
+            {referential_actions}
             NOT VALID
             "#,
             table = table.real_name,
@@ -56,6 +57,7 @@ impl Action for AddForeignKey {
             columns = columns.join(", "),
             referenced_table = referenced_table.real_name,
             referenced_columns = referenced_columns.join(", "),
+            referential_actions = self.foreign_key.referential_actions_definition(),
         ))
         .context("failed to create foreign key")?;
 

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -24,6 +24,60 @@ pub struct ForeignKey {
     pub columns: Vec<String>,
     pub referenced_table: String,
     pub referenced_columns: Vec<String>,
+    pub on_delete: Option<ReferentialAction>,
+    pub on_update: Option<ReferentialAction>,
+}
+
+impl ForeignKey {
+    // Renders the ON DELETE and ON UPDATE clauses, if any. The clauses have to be placed
+    // directly after the REFERENCES clause and before any constraint attributes, such as
+    // NOT VALID.
+    pub fn referential_actions_definition(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+
+        if let Some(on_delete) = &self.on_delete {
+            parts.push(format!("ON DELETE {}", on_delete.as_sql()));
+        }
+
+        if let Some(on_update) = &self.on_update {
+            parts.push(format!("ON UPDATE {}", on_update.as_sql()));
+        }
+
+        parts.join(" ")
+    }
+}
+
+// The referential action taken when the referenced row is deleted or updated.
+// Deserialized from the same keywords Postgres uses, for example "CASCADE" or
+// "SET NULL", in either upper or lower case.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReferentialAction {
+    #[serde(rename = "NO ACTION", alias = "no action")]
+    NoAction,
+
+    #[serde(rename = "RESTRICT", alias = "restrict")]
+    Restrict,
+
+    #[serde(rename = "CASCADE", alias = "cascade")]
+    Cascade,
+
+    #[serde(rename = "SET NULL", alias = "set null")]
+    SetNull,
+
+    #[serde(rename = "SET DEFAULT", alias = "set default")]
+    SetDefault,
+}
+
+impl ReferentialAction {
+    pub fn as_sql(&self) -> &'static str {
+        match self {
+            ReferentialAction::NoAction => "NO ACTION",
+            ReferentialAction::Restrict => "RESTRICT",
+            ReferentialAction::Cascade => "CASCADE",
+            ReferentialAction::SetNull => "SET NULL",
+            ReferentialAction::SetDefault => "SET DEFAULT",
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -95,11 +95,12 @@ impl Action for CreateTable {
 
             definition_rows.push(format!(
                 r#"
-                FOREIGN KEY ({columns}) REFERENCES "{table}" ({referenced_columns})
+                FOREIGN KEY ({columns}) REFERENCES "{table}" ({referenced_columns}) {referential_actions}
                 "#,
                 columns = columns.join(", "),
                 table = referenced_table.real_name,
                 referenced_columns = referenced_columns.join(", "),
+                referential_actions = foreign_key.referential_actions_definition(),
             ));
         }
 

--- a/tests/add_foreign_key.rs
+++ b/tests/add_foreign_key.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::Test;
+use reshape::migrations::Migration;
 
 #[test]
 fn add_foreign_key() {
@@ -163,4 +164,181 @@ fn add_invalid_foreign_key() {
 
     test.expect_failure();
     test.run()
+}
+
+#[test]
+fn add_foreign_key_with_referential_actions() {
+    let mut test = Test::new("Add foreign key with referential actions");
+
+    test.first_migration(
+        r#"
+        name = "create_user_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+        [[actions]]
+        type = "create_table"
+        name = "items"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_foreign_key"
+
+        [[actions]]
+        type = "add_foreign_key"
+        table = "items"
+
+            [actions.foreign_key]
+            columns = ["user_id"]
+            referenced_table = "users"
+            referenced_columns = ["id"]
+            on_delete = "CASCADE"
+            on_update = "CASCADE"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id) VALUES (1), (2), (3)")
+            .unwrap();
+        db.simple_query("INSERT INTO items (id, user_id) VALUES (1, 1), (2, 2), (3, 3)")
+            .unwrap();
+    });
+
+    test.intermediate(|db, _| {
+        // Ensure the referential actions are in place as soon as the migration has started
+        let (on_delete, on_update): (i8, i8) = db
+            .query(
+                "
+                SELECT confdeltype, confupdtype
+                FROM pg_constraint
+                WHERE contype = 'f' AND conrelid = 'public.items'::regclass
+                ",
+                &[],
+            )
+            .unwrap()
+            .first()
+            .map(|row| (row.get("confdeltype"), row.get("confupdtype")))
+            .unwrap();
+        assert_eq!(b'c' as i8, on_delete, "expected ON DELETE CASCADE");
+        assert_eq!(b'c' as i8, on_update, "expected ON UPDATE CASCADE");
+
+        // Ensure deletes cascade
+        db.simple_query("DELETE FROM users WHERE id = 1").unwrap();
+        let remaining = db
+            .query("SELECT id FROM items WHERE id = 1", &[])
+            .unwrap()
+            .len();
+        assert_eq!(0, remaining, "expected item to be deleted by cascade");
+
+        // Ensure updates cascade
+        db.simple_query("UPDATE users SET id = 20 WHERE id = 2")
+            .unwrap();
+        let user_id: i32 = db
+            .query("SELECT user_id FROM items WHERE id = 2", &[])
+            .unwrap()
+            .first()
+            .map(|row| row.get("user_id"))
+            .unwrap();
+        assert_eq!(20, user_id, "expected item to be updated by cascade");
+    });
+
+    test.after_completion(|db| {
+        // Ensure the referential actions survive the constraint being renamed
+        let (name, on_delete, on_update): (String, i8, i8) = db
+            .query(
+                "
+                SELECT conname, confdeltype, confupdtype
+                FROM pg_constraint
+                WHERE contype = 'f' AND conrelid = 'public.items'::regclass
+                ",
+                &[],
+            )
+            .unwrap()
+            .first()
+            .map(|row| {
+                (
+                    row.get("conname"),
+                    row.get("confdeltype"),
+                    row.get("confupdtype"),
+                )
+            })
+            .unwrap();
+        assert_eq!("items_user_id_fkey", name);
+        assert_eq!(b'c' as i8, on_delete, "expected ON DELETE CASCADE");
+        assert_eq!(b'c' as i8, on_update, "expected ON UPDATE CASCADE");
+
+        db.simple_query("DELETE FROM users WHERE id = 3").unwrap();
+        let remaining = db
+            .query("SELECT id FROM items WHERE id = 3", &[])
+            .unwrap()
+            .len();
+        assert_eq!(0, remaining, "expected item to be deleted by cascade");
+    });
+
+    test.after_abort(|db| {
+        // Ensure the foreign key, and with it the cascade, is gone
+        let fk_does_not_exist = db
+            .query(
+                "
+                SELECT conname
+                FROM pg_constraint
+                WHERE contype = 'f' AND conrelid = 'public.items'::regclass
+                ",
+                &[],
+            )
+            .unwrap()
+            .is_empty();
+        assert!(fk_does_not_exist);
+
+        db.simple_query("DELETE FROM users WHERE id = 3").unwrap();
+        let remaining = db
+            .query("SELECT id FROM items WHERE id = 3", &[])
+            .unwrap()
+            .len();
+        assert_eq!(1, remaining, "expected item to be left untouched");
+    });
+
+    test.run()
+}
+
+#[test]
+fn add_foreign_key_invalid_referential_action() {
+    let result = toml::from_str::<Migration>(
+        r#"
+        name = "add_foreign_key"
+
+        [[actions]]
+        type = "add_foreign_key"
+        table = "items"
+
+            [actions.foreign_key]
+            columns = ["user_id"]
+            referenced_table = "users"
+            referenced_columns = ["id"]
+            on_delete = "DROP EVERYTHING"
+        "#,
+    );
+
+    assert!(
+        result.is_err(),
+        "expected an unknown referential action to be rejected"
+    );
 }

--- a/tests/create_table.rs
+++ b/tests/create_table.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::{assert_invalid_sql, Test};
+use reshape::migrations::Migration;
 
 #[test]
 fn create_table_invalid_default_sql() {
@@ -237,4 +238,118 @@ fn create_table_with_foreign_keys() {
     });
 
     test.run();
+}
+
+#[test]
+fn create_table_with_referential_actions() {
+    let mut test = Test::new("Create table with referential actions");
+
+    test.first_migration(
+        r#"
+        name = "create_users_and_items_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+        [[actions]]
+        type = "create_table"
+        name = "items"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+            [[actions.foreign_keys]]
+            columns = ["user_id"]
+            referenced_table = "users"
+            referenced_columns = ["id"]
+            on_delete = "CASCADE"
+            on_update = "SET NULL"
+        "#,
+    );
+
+    test.after_first(|db| {
+        // Ensure the referential actions were applied to the constraint
+        let (on_delete, on_update): (i8, i8) = db
+            .query(
+                "
+                SELECT confdeltype, confupdtype
+                FROM pg_constraint
+                WHERE contype = 'f' AND conrelid = 'public.items'::regclass
+                ",
+                &[],
+            )
+            .unwrap()
+            .first()
+            .map(|row| (row.get("confdeltype"), row.get("confupdtype")))
+            .unwrap();
+        assert_eq!(b'c' as i8, on_delete, "expected ON DELETE CASCADE");
+        assert_eq!(b'n' as i8, on_update, "expected ON UPDATE SET NULL");
+
+        db.simple_query("INSERT INTO users (id) VALUES (1), (2)")
+            .unwrap();
+        db.simple_query("INSERT INTO items (id, user_id) VALUES (1, 1), (2, 2)")
+            .unwrap();
+
+        // Ensure updates set the referencing column to NULL
+        db.simple_query("UPDATE users SET id = 20 WHERE id = 1")
+            .unwrap();
+        let user_id: Option<i32> = db
+            .query("SELECT user_id FROM items WHERE id = 1", &[])
+            .unwrap()
+            .first()
+            .map(|row| row.get("user_id"))
+            .unwrap();
+        assert_eq!(None, user_id, "expected user_id to be set to NULL");
+
+        // Ensure deletes cascade
+        db.simple_query("DELETE FROM users WHERE id = 2").unwrap();
+        let remaining = db
+            .query("SELECT id FROM items WHERE id = 2", &[])
+            .unwrap()
+            .len();
+        assert_eq!(0, remaining, "expected item to be deleted by cascade");
+    });
+
+    test.run()
+}
+
+#[test]
+fn create_table_invalid_referential_action() {
+    let result = toml::from_str::<Migration>(
+        r#"
+        name = "create_items_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "items"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.foreign_keys]]
+            columns = ["user_id"]
+            referenced_table = "users"
+            referenced_columns = ["id"]
+            on_delete = "MAYBE"
+        "#,
+    );
+
+    assert!(
+        result.is_err(),
+        "expected an unknown referential action to be rejected"
+    );
 }


### PR DESCRIPTION
Foreign keys could previously only be created with Postgres' default `NO ACTION` referential behaviour, so every cascading foreign key had to be written as a `custom` `ALTER TABLE ... ADD CONSTRAINT` — even though `add_foreign_key` would otherwise have been the right action.

## Changes

`common::ForeignKey` gains optional `on_delete` and `on_update` fields, emitted by both `create_table` and `add_foreign_key`:

```toml
[[actions]]
type = "add_foreign_key"
table = "items"

    [actions.foreign_key]
    columns = ["user_id"]
    referenced_table = "users"
    referenced_columns = ["id"]
    on_delete = "CASCADE"
    on_update = "SET NULL"
```

The actions deserialize into a `ReferentialAction` enum (`NO ACTION`, `RESTRICT`, `CASCADE`, `SET NULL`, `SET DEFAULT`, upper or lower case) rather than being passed through as raw SQL, so an unknown keyword is rejected when the migration file is parsed instead of failing against the database.

The clauses are rendered between `REFERENCES` and the constraint attributes, so `add_foreign_key` still creates the constraint as `NOT VALID` and validates it separately. Zero-downtime behaviour is unchanged — referential actions are invisible to the old application version.

## Tests

- `add_foreign_key_with_referential_actions` — asserts `confdeltype`/`confupdtype` in `pg_constraint` and that deletes/updates actually cascade, checked at the intermediate stage, after completion (surviving the constraint rename), and after abort (constraint and cascade gone).
- `create_table_with_referential_actions` — `ON DELETE CASCADE` plus `ON UPDATE SET NULL` declared inline on `create_table`.
- `add_foreign_key_invalid_referential_action` / `create_table_invalid_referential_action` — an unknown keyword fails to parse.

Docs updated in `src/docs/actions/{add-foreign-key,create-table}.md` and the README.

Full suite passes and `cargo clippy -- -D warnings` is clean.