### PR TITLE
Support partial, expression and sorted indexes, and fix column order

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,8 +585,6 @@ table = "users"
 	unique = true
 ```
 
-Expressions and `where` predicates are passed to Postgres as written, so they reference the table's real columns. The exception is a column being replaced by an `alter_column` in the same migration: the original column is dropped when the migration completes and would take the index with it, so an index whose expression or predicate references such a column is rejected.
-
 _Example: add GIN index to `data` column on `products` table_
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ table = "users"
 	unique = true
 ```
 
-Expressions and `where` predicates are passed to Postgres as written. Reshape can't rewrite the column references inside them to point at the temporary columns used during a migration, so an index using either will be rejected if any column of the table is being changed in the same migration.
+Expressions and `where` predicates are passed to Postgres as written, so they reference the table's real columns. The exception is a column being replaced by an `alter_column` in the same migration: the original column is dropped when the migration completes and would take the index with it, so an index whose expression or predicate references such a column is rejected.
 
 _Example: add GIN index to `data` column on `products` table_
 

--- a/README.md
+++ b/README.md
@@ -550,6 +550,43 @@ table = "users"
 	unique = true
 ```
 
+_Example: add a partial index with a custom sort order to the `posts` table_
+
+```toml
+[[actions]]
+type = "add_index"
+table = "posts"
+
+	[actions.index]
+	name = "posts_keyset_idx"
+
+	# An entry is either a plain column name or a table with more detail.
+	# The entries are indexed in the order they are declared.
+	columns = [
+		"audience",
+		{ column = "content_updated_at", direction = "DESC", nulls = "LAST" },
+		"id",
+	]
+
+	# Optional, makes the index partial. Written without the WHERE keyword
+	where = "is_public AND shared_to_community"
+```
+
+_Example: add a unique index on an expression to the `users` table_
+
+```toml
+[[actions]]
+type = "add_index"
+table = "users"
+
+	[actions.index]
+	name = "users_email_idx"
+	columns = [{ expression = "lower(email)" }]
+	unique = true
+```
+
+Expressions and `where` predicates are passed to Postgres as written. Reshape can't rewrite the column references inside them to point at the temporary columns used during a migration, so an index using either will be rejected if any column of the table is being changed in the same migration.
+
 _Example: add GIN index to `data` column on `products` table_
 
 ```toml

--- a/src/docs/actions/add-index.md
+++ b/src/docs/actions/add-index.md
@@ -160,8 +160,8 @@ table = "documents"
 - Indexes are created concurrently to avoid blocking
 - The index is immediately available after the start phase
 - For unique indexes, existing data must not have duplicates
-- Plain column references are automatically rewritten to the temporary column when a
-  column is being migrated in the same migration, so indexing a column added or altered
-  by an earlier action works as expected
-- Expressions and `where` predicates are passed to Postgres as written, so they reference
-  the table's real columns
+- Expressions and `where` predicates are passed to Postgres as written rather than being
+  resolved by Reshape, so they reference the table's real columns. Avoid referencing a
+  column which is being altered or renamed in the same migration: `alter_column` replaces
+  the column rather than modifying it in place, so creating the index can fail, and an
+  index that is created may be dropped again when the migration is completed

--- a/src/docs/actions/add-index.md
+++ b/src/docs/actions/add-index.md
@@ -164,8 +164,4 @@ table = "documents"
   column is being migrated in the same migration, so indexing a column added or altered
   by an earlier action works as expected
 - Expressions and `where` predicates are passed to Postgres as written, so they reference
-  the table's real columns. This is usually what you want, including alongside other
-  column changes in the same migration. The exception is a column being *replaced* by an
-  `alter_column` in the same migration: the original column is dropped on completion and
-  would take the index with it, so an index whose expression or predicate references such
-  a column is rejected. Move the index to a later migration in that case
+  the table's real columns

--- a/src/docs/actions/add-index.md
+++ b/src/docs/actions/add-index.md
@@ -14,6 +14,7 @@ table = "table_name"          # Required: table to index
     columns = ["col1", "col2"]
     unique = false            # Optional: default false
     type = "btree"            # Optional: index type
+    where = "col1 IS NOT NULL"  # Optional: predicate for a partial index
 ```
 
 ## Fields
@@ -25,6 +26,29 @@ table = "table_name"          # Required: table to index
 | `index.columns` | array | Yes | Columns to index |
 | `index.unique` | boolean | No | Create unique index (default: false) |
 | `index.type` | string | No | Index type (btree, hash, gist, etc.) |
+| `index.where` | string | No | Predicate for a partial index, without the `WHERE` keyword |
+
+## Index Columns
+
+Each entry in `index.columns` is either a plain column name or a table with more detail.
+The order of the entries is the order of the columns in the index.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `column` | string | Yes\* | Column to index |
+| `expression` | string | Yes\* | Expression to index, instead of a column |
+| `direction` | string | No | `ASC` (default) or `DESC` |
+| `nulls` | string | No | `FIRST` or `LAST`. Defaults to `LAST` for `ASC` and `FIRST` for `DESC` |
+
+\* Exactly one of `column` and `expression` must be set.
+
+```toml
+columns = [
+    "audience",
+    { column = "content_updated_at", direction = "DESC", nulls = "LAST" },
+    { expression = "lower(email)" },
+]
+```
 
 ## Examples
 
@@ -65,6 +89,50 @@ table = "orders"
     columns = ["user_id", "created_at"]
 ```
 
+### Index with Sort Order
+
+Useful for keyset pagination, where the index has to match the query's `ORDER BY`:
+
+```toml
+[[actions]]
+type = "add_index"
+table = "posts"
+
+    [actions.index]
+    name = "posts_keyset_idx"
+    columns = [
+        "audience",
+        { column = "content_updated_at", direction = "DESC" },
+        "id",
+    ]
+```
+
+### Partial Index
+
+```toml
+[[actions]]
+type = "add_index"
+table = "posts"
+
+    [actions.index]
+    name = "posts_community_idx"
+    columns = ["audience", "id"]
+    where = "is_public AND shared_to_community"
+```
+
+### Expression Index
+
+```toml
+[[actions]]
+type = "add_index"
+table = "users"
+
+    [actions.index]
+    name = "users_email_idx"
+    unique = true
+    columns = [{ expression = "lower(email)" }]
+```
+
 ### GIN Index
 
 ```toml
@@ -92,3 +160,10 @@ table = "documents"
 - Indexes are created concurrently to avoid blocking
 - The index is immediately available after the start phase
 - For unique indexes, existing data must not have duplicates
+- Plain column references are automatically rewritten to the temporary column when a
+  column is being migrated in the same migration, so indexing a column added or altered
+  by an earlier action works as expected
+- Expressions and `where` predicates are passed through as written. Reshape can't rewrite
+  the column references inside them, so an index using either will be rejected if any
+  column of the table is being migrated in the same migration. Move the index to a later
+  migration in that case

--- a/src/docs/actions/add-index.md
+++ b/src/docs/actions/add-index.md
@@ -163,7 +163,9 @@ table = "documents"
 - Plain column references are automatically rewritten to the temporary column when a
   column is being migrated in the same migration, so indexing a column added or altered
   by an earlier action works as expected
-- Expressions and `where` predicates are passed through as written. Reshape can't rewrite
-  the column references inside them, so an index using either will be rejected if any
-  column of the table is being migrated in the same migration. Move the index to a later
-  migration in that case
+- Expressions and `where` predicates are passed to Postgres as written, so they reference
+  the table's real columns. This is usually what you want, including alongside other
+  column changes in the same migration. The exception is a column being *replaced* by an
+  `alter_column` in the same migration: the original column is dropped on completion and
+  would take the index with it, so an index whose expression or predicate references such
+  a column is rejected. Move the index to a later migration in that case

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{Conn, Transaction},
     schema::{Schema, Table},
 };
-use anyhow::{bail, Context};
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -88,16 +88,6 @@ fn sort_definition(direction: &Option<Direction>, nulls: &Option<Nulls>) -> Stri
 }
 
 impl Index {
-    // Whether the index relies on user-provided SQL, which is passed to Postgres as
-    // written rather than having its column references resolved by Reshape.
-    fn has_raw_sql(&self) -> bool {
-        self.r#where.is_some()
-            || self
-                .columns
-                .iter()
-                .any(|column| matches!(column, IndexColumn::Expression(_)))
-    }
-
     fn column_definitions(&self, table: &Table) -> Vec<String> {
         self.columns
             .iter()
@@ -133,81 +123,6 @@ fn real_column_name(table: &Table, name: &str) -> String {
     format!("\"{}\"", real_name)
 }
 
-// Name of the temporary view used to work out which columns an index references.
-// Temporary views are session scoped, so this can't collide with another Reshape run.
-const PROBE_VIEW_NAME: &str = "__reshape_index_probe";
-
-impl AddIndex {
-    // Works out which columns of the table the index's expressions and predicate
-    // reference, by declaring them as a temporary view and asking Postgres what that view
-    // depends on. This gets the resolution exactly right without Reshape having to parse
-    // the SQL, and unlike creating the index it doesn't scan the table.
-    //
-    // Returns None if the probe can't be created, for example because the SQL references
-    // a column which doesn't exist. The CREATE INDEX statement will fail with the same
-    // error, which is the more useful place for it to surface.
-    fn referenced_columns(&self, db: &mut dyn Conn, table: &Table) -> Option<Vec<String>> {
-        let selects: Vec<String> = self
-            .index
-            .columns
-            .iter()
-            .enumerate()
-            .map(|(idx, column)| {
-                let target = match column {
-                    IndexColumn::Name(name) => real_column_name(table, name),
-                    IndexColumn::Column(spec) => real_column_name(table, &spec.column),
-                    IndexColumn::Expression(spec) => format!("({})", spec.expression),
-                };
-
-                format!("{target} AS c{idx}")
-            })
-            .collect();
-
-        let where_def = match &self.index.r#where {
-            Some(predicate) => format!("WHERE {predicate}"),
-            None => "".to_string(),
-        };
-
-        let drop_query = format!(r#"DROP VIEW IF EXISTS pg_temp."{PROBE_VIEW_NAME}""#);
-        db.run(&drop_query).ok()?;
-        db.run(&format!(
-            r#"
-            CREATE VIEW pg_temp."{view}" AS
-                SELECT {selects}
-                FROM public."{table}"
-                {where_def}
-            "#,
-            view = PROBE_VIEW_NAME,
-            selects = selects.join(", "),
-            table = table.real_name,
-        ))
-        .ok()?;
-
-        let columns = db
-            .query(&format!(
-                r#"
-                SELECT DISTINCT attribute.attname AS name
-                FROM pg_depend dependency
-                JOIN pg_rewrite rule ON rule.oid = dependency.objid
-                JOIN pg_attribute attribute ON
-                    attribute.attrelid = dependency.refobjid AND
-                    attribute.attnum = dependency.refobjsubid
-                WHERE rule.ev_class = 'pg_temp."{view}"'::regclass
-                    AND dependency.refclassid = 'pg_class'::regclass
-                    AND dependency.refobjid = 'public."{table}"'::regclass
-                    AND dependency.refobjsubid > 0
-                "#,
-                view = PROBE_VIEW_NAME,
-                table = table.real_name,
-            ))
-            .map(|rows| rows.iter().map(|row| row.get("name")).collect());
-
-        db.run(&drop_query).ok()?;
-
-        columns.ok()
-    }
-}
-
 #[typetag::serde(name = "add_index")]
 impl Action for AddIndex {
     fn describe(&self) -> String {
@@ -224,34 +139,6 @@ impl Action for AddIndex {
         schema: &Schema,
     ) -> anyhow::Result<()> {
         let table = schema.get_table(db, &self.table)?;
-
-        // Expressions and predicates are passed to Postgres as written, which means they
-        // reference the real columns of the table. Most of the time that's fine, but a
-        // column which is being replaced in this migration will be dropped on completion,
-        // taking any index built on it along with it. That would leave the migration
-        // looking successful with the index silently gone, so reject it instead.
-        if self.index.has_raw_sql() {
-            if let Some(columns) = self.referenced_columns(db, &table) {
-                for column in columns {
-                    if !table
-                        .columns
-                        .iter()
-                        .any(|surviving| surviving.real_name == column)
-                    {
-                        bail!(
-                            "index \"{index}\" references column \"{column}\" of table \
-                             \"{table}\" in an expression or a WHERE predicate, but that column \
-                             is being replaced or removed in this migration. The index would be \
-                             dropped along with the column when the migration is completed. Move \
-                             the index to a later migration.",
-                            index = self.index.name,
-                            column = column,
-                            table = table.name,
-                        );
-                    }
-                }
-            }
-        }
 
         let unique = if self.index.unique { "UNIQUE" } else { "" };
         let index_type_def = if let Some(index_type) = &self.index.index_type {

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -1,9 +1,9 @@
-use super::{Action, MigrationContext};
+use super::{validate_sql_expression, Action, MigrationContext};
 use crate::{
     db::{Conn, Transaction},
-    schema::Schema,
+    schema::{Schema, Table},
 };
-use anyhow::Context;
+use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -15,11 +15,123 @@ pub struct AddIndex {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Index {
     pub name: String,
-    pub columns: Vec<String>,
+    pub columns: Vec<IndexColumn>,
     #[serde(default)]
     pub unique: bool,
     #[serde(rename = "type")]
     pub index_type: Option<String>,
+
+    // Predicate for a partial index, without the WHERE keyword
+    pub r#where: Option<String>,
+}
+
+// A single entry in an index. Can either be a plain column name, a column with an
+// explicit sort order or an arbitrary expression.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum IndexColumn {
+    Name(String),
+    Column(IndexColumnSpec),
+    Expression(IndexExpressionSpec),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct IndexColumnSpec {
+    pub column: String,
+    pub direction: Option<Direction>,
+    pub nulls: Option<Nulls>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct IndexExpressionSpec {
+    pub expression: String,
+    pub direction: Option<Direction>,
+    pub nulls: Option<Nulls>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    #[serde(rename = "ASC", alias = "asc")]
+    Asc,
+
+    #[serde(rename = "DESC", alias = "desc")]
+    Desc,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Nulls {
+    #[serde(rename = "FIRST", alias = "first")]
+    First,
+
+    #[serde(rename = "LAST", alias = "last")]
+    Last,
+}
+
+fn sort_definition(direction: &Option<Direction>, nulls: &Option<Nulls>) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+
+    match direction {
+        Some(Direction::Asc) => parts.push("ASC"),
+        Some(Direction::Desc) => parts.push("DESC"),
+        None => {}
+    }
+
+    match nulls {
+        Some(Nulls::First) => parts.push("NULLS FIRST"),
+        Some(Nulls::Last) => parts.push("NULLS LAST"),
+        None => {}
+    }
+
+    parts.join(" ")
+}
+
+impl Index {
+    // Whether the index relies on any user-provided SQL which references columns by name.
+    // Reshape can't rewrite those references to point at temporary columns, so such an
+    // index can't be created while the table's columns are being migrated.
+    fn has_raw_sql(&self) -> bool {
+        self.r#where.is_some()
+            || self
+                .columns
+                .iter()
+                .any(|column| matches!(column, IndexColumn::Expression(_)))
+    }
+
+    fn column_definitions(&self, table: &Table) -> Vec<String> {
+        self.columns
+            .iter()
+            .map(|column| {
+                let (target, direction, nulls) = match column {
+                    IndexColumn::Name(name) => (real_column_name(table, name), &None, &None),
+                    IndexColumn::Column(spec) => (
+                        real_column_name(table, &spec.column),
+                        &spec.direction,
+                        &spec.nulls,
+                    ),
+                    IndexColumn::Expression(spec) => (
+                        format!("({})", spec.expression),
+                        &spec.direction,
+                        &spec.nulls,
+                    ),
+                };
+
+                format!("{} {}", target, sort_definition(direction, nulls))
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+}
+
+fn real_column_name(table: &Table, name: &str) -> String {
+    let real_name = table
+        .get_column(name)
+        .map(|column| column.real_name.as_ref())
+        .unwrap_or(name);
+
+    format!("\"{}\"", real_name)
 }
 
 #[typetag::serde(name = "add_index")]
@@ -39,12 +151,29 @@ impl Action for AddIndex {
     ) -> anyhow::Result<()> {
         let table = schema.get_table(db, &self.table)?;
 
-        let column_real_names: Vec<String> = table
-            .columns
-            .iter()
-            .filter(|column| self.index.columns.contains(&column.name))
-            .map(|column| format!("\"{}\"", column.real_name))
-            .collect();
+        // Columns which are being migrated are temporarily backed by a different column.
+        // Plain column references are rewritten to the temporary column but expressions
+        // and predicates are passed through as written, so they would silently reference
+        // the wrong column. Reject the index instead of creating a broken one.
+        if self.index.has_raw_sql() {
+            if let Some(column) = table
+                .columns
+                .iter()
+                .find(|column| column.name != column.real_name)
+            {
+                bail!(
+                    "index \"{index}\" uses an expression or a WHERE predicate, which can't be \
+                     combined with changes to the columns of table \"{table}\" in the same \
+                     migration. Column \"{column}\" is currently backed by the temporary column \
+                     \"{real_column}\". Move the index to a later migration or use plain column \
+                     references instead.",
+                    index = self.index.name,
+                    table = table.name,
+                    column = column.name,
+                    real_column = column.real_name,
+                );
+            }
+        }
 
         let unique = if self.index.unique { "UNIQUE" } else { "" };
         let index_type_def = if let Some(index_type) = &self.index.index_type {
@@ -52,14 +181,19 @@ impl Action for AddIndex {
         } else {
             "".to_string()
         };
+        let where_def = if let Some(predicate) = &self.index.r#where {
+            format!("WHERE {predicate}")
+        } else {
+            "".to_string()
+        };
 
         db.run(&format!(
             r#"
-			CREATE {unique} INDEX CONCURRENTLY "{name}" ON "{table}" {index_type_def} ({columns}) 
+			CREATE {unique} INDEX CONCURRENTLY "{name}" ON "{table}" {index_type_def} ({columns}) {where_def}
 			"#,
             name = self.index.name,
-            table = self.table,
-            columns = column_real_names.join(", "),
+            table = table.real_name,
+            columns = self.index.column_definitions(&table).join(", "),
         ))
         .context("failed to create index")?;
         Ok(())
@@ -84,5 +218,29 @@ impl Action for AddIndex {
         ))
         .context("failed to drop index")?;
         Ok(())
+    }
+
+    fn validate_sql(&self) -> Vec<(String, String, String)> {
+        let mut errors = vec![];
+
+        for (idx, column) in self.index.columns.iter().enumerate() {
+            if let IndexColumn::Expression(spec) = column {
+                if let Err(e) = validate_sql_expression(&spec.expression) {
+                    errors.push((
+                        format!("index.columns[{}].expression", idx),
+                        spec.expression.clone(),
+                        e,
+                    ));
+                }
+            }
+        }
+
+        if let Some(predicate) = &self.index.r#where {
+            if let Err(e) = validate_sql_expression(predicate) {
+                errors.push(("index.where".to_string(), predicate.clone(), e));
+            }
+        }
+
+        errors
     }
 }

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -88,9 +88,8 @@ fn sort_definition(direction: &Option<Direction>, nulls: &Option<Nulls>) -> Stri
 }
 
 impl Index {
-    // Whether the index relies on any user-provided SQL which references columns by name.
-    // Reshape can't rewrite those references to point at temporary columns, so such an
-    // index can't be created while the table's columns are being migrated.
+    // Whether the index relies on user-provided SQL, which is passed to Postgres as
+    // written rather than having its column references resolved by Reshape.
     fn has_raw_sql(&self) -> bool {
         self.r#where.is_some()
             || self
@@ -134,6 +133,81 @@ fn real_column_name(table: &Table, name: &str) -> String {
     format!("\"{}\"", real_name)
 }
 
+// Name of the temporary view used to work out which columns an index references.
+// Temporary views are session scoped, so this can't collide with another Reshape run.
+const PROBE_VIEW_NAME: &str = "__reshape_index_probe";
+
+impl AddIndex {
+    // Works out which columns of the table the index's expressions and predicate
+    // reference, by declaring them as a temporary view and asking Postgres what that view
+    // depends on. This gets the resolution exactly right without Reshape having to parse
+    // the SQL, and unlike creating the index it doesn't scan the table.
+    //
+    // Returns None if the probe can't be created, for example because the SQL references
+    // a column which doesn't exist. The CREATE INDEX statement will fail with the same
+    // error, which is the more useful place for it to surface.
+    fn referenced_columns(&self, db: &mut dyn Conn, table: &Table) -> Option<Vec<String>> {
+        let selects: Vec<String> = self
+            .index
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(idx, column)| {
+                let target = match column {
+                    IndexColumn::Name(name) => real_column_name(table, name),
+                    IndexColumn::Column(spec) => real_column_name(table, &spec.column),
+                    IndexColumn::Expression(spec) => format!("({})", spec.expression),
+                };
+
+                format!("{target} AS c{idx}")
+            })
+            .collect();
+
+        let where_def = match &self.index.r#where {
+            Some(predicate) => format!("WHERE {predicate}"),
+            None => "".to_string(),
+        };
+
+        let drop_query = format!(r#"DROP VIEW IF EXISTS pg_temp."{PROBE_VIEW_NAME}""#);
+        db.run(&drop_query).ok()?;
+        db.run(&format!(
+            r#"
+            CREATE VIEW pg_temp."{view}" AS
+                SELECT {selects}
+                FROM public."{table}"
+                {where_def}
+            "#,
+            view = PROBE_VIEW_NAME,
+            selects = selects.join(", "),
+            table = table.real_name,
+        ))
+        .ok()?;
+
+        let columns = db
+            .query(&format!(
+                r#"
+                SELECT DISTINCT attribute.attname AS name
+                FROM pg_depend dependency
+                JOIN pg_rewrite rule ON rule.oid = dependency.objid
+                JOIN pg_attribute attribute ON
+                    attribute.attrelid = dependency.refobjid AND
+                    attribute.attnum = dependency.refobjsubid
+                WHERE rule.ev_class = 'pg_temp."{view}"'::regclass
+                    AND dependency.refclassid = 'pg_class'::regclass
+                    AND dependency.refobjid = 'public."{table}"'::regclass
+                    AND dependency.refobjsubid > 0
+                "#,
+                view = PROBE_VIEW_NAME,
+                table = table.real_name,
+            ))
+            .map(|rows| rows.iter().map(|row| row.get("name")).collect());
+
+        db.run(&drop_query).ok()?;
+
+        columns.ok()
+    }
+}
+
 #[typetag::serde(name = "add_index")]
 impl Action for AddIndex {
     fn describe(&self) -> String {
@@ -151,27 +225,31 @@ impl Action for AddIndex {
     ) -> anyhow::Result<()> {
         let table = schema.get_table(db, &self.table)?;
 
-        // Columns which are being migrated are temporarily backed by a different column.
-        // Plain column references are rewritten to the temporary column but expressions
-        // and predicates are passed through as written, so they would silently reference
-        // the wrong column. Reject the index instead of creating a broken one.
+        // Expressions and predicates are passed to Postgres as written, which means they
+        // reference the real columns of the table. Most of the time that's fine, but a
+        // column which is being replaced in this migration will be dropped on completion,
+        // taking any index built on it along with it. That would leave the migration
+        // looking successful with the index silently gone, so reject it instead.
         if self.index.has_raw_sql() {
-            if let Some(column) = table
-                .columns
-                .iter()
-                .find(|column| column.name != column.real_name)
-            {
-                bail!(
-                    "index \"{index}\" uses an expression or a WHERE predicate, which can't be \
-                     combined with changes to the columns of table \"{table}\" in the same \
-                     migration. Column \"{column}\" is currently backed by the temporary column \
-                     \"{real_column}\". Move the index to a later migration or use plain column \
-                     references instead.",
-                    index = self.index.name,
-                    table = table.name,
-                    column = column.name,
-                    real_column = column.real_name,
-                );
+            if let Some(columns) = self.referenced_columns(db, &table) {
+                for column in columns {
+                    if !table
+                        .columns
+                        .iter()
+                        .any(|surviving| surviving.real_name == column)
+                    {
+                        bail!(
+                            "index \"{index}\" references column \"{column}\" of table \
+                             \"{table}\" in an expression or a WHERE predicate, but that column \
+                             is being replaced or removed in this migration. The index would be \
+                             dropped along with the column when the migration is completed. Move \
+                             the index to a later migration.",
+                            index = self.index.name,
+                            column = column,
+                            table = table.name,
+                        );
+                    }
+                }
             }
         }
 

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -1,4 +1,4 @@
-use super::{validate_sql_expression, Action, MigrationContext};
+use super::{Action, MigrationContext};
 use crate::{
     db::{Conn, Transaction},
     schema::{Schema, Table},
@@ -218,29 +218,5 @@ impl Action for AddIndex {
         ))
         .context("failed to drop index")?;
         Ok(())
-    }
-
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        let mut errors = vec![];
-
-        for (idx, column) in self.index.columns.iter().enumerate() {
-            if let IndexColumn::Expression(spec) = column {
-                if let Err(e) = validate_sql_expression(&spec.expression) {
-                    errors.push((
-                        format!("index.columns[{}].expression", idx),
-                        spec.expression.clone(),
-                        e,
-                    ));
-                }
-            }
-        }
-
-        if let Some(predicate) = &self.index.r#where {
-            if let Err(e) = validate_sql_expression(predicate) {
-                errors.push(("index.where".to_string(), predicate.clone(), e));
-            }
-        }
-
-        errors
     }
 }

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{assert_invalid_sql, Test};
+use common::Test;
 
 #[test]
 fn add_index() {
@@ -220,37 +220,6 @@ fn add_index_with_type() {
     });
 
     test.run();
-}
-
-#[test]
-fn add_index_invalid_expression_sql() {
-    assert_invalid_sql(
-        r#"
-        name = "test"
-        [[actions]]
-        type = "add_index"
-        table = "users"
-        [actions.index]
-        name = "name_idx"
-        columns = [{ expression = "INVALID $$$ SYNTAX" }]
-        "#,
-    );
-}
-
-#[test]
-fn add_index_invalid_where_sql() {
-    assert_invalid_sql(
-        r#"
-        name = "test"
-        [[actions]]
-        type = "add_index"
-        table = "users"
-        [actions.index]
-        name = "name_idx"
-        columns = ["name"]
-        where = "INVALID $$$ SYNTAX"
-        "#,
-    );
 }
 
 #[test]

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -643,65 +643,6 @@ fn add_index_with_expression_alongside_a_column_migration() {
     test.run();
 }
 
-#[test]
-fn add_index_with_expression_to_renamed_column() {
-    let mut test = Test::new("Add expression index to renamed column");
-
-    test.first_migration(
-        r#"
-        name = "create_users_table"
-
-        [[actions]]
-        type = "create_table"
-        name = "users"
-        primary_key = ["id"]
-
-            [[actions.columns]]
-            name = "id"
-            type = "INTEGER"
-
-            [[actions.columns]]
-            name = "email"
-            type = "TEXT"
-        "#,
-    );
-
-    // A rename keeps the same underlying column, so the index follows it and the
-    // expression is written against the column's current, real name
-    test.second_migration(
-        r#"
-        name = "rename_email_and_index_it"
-
-        [[actions]]
-        type = "alter_column"
-        table = "users"
-        column = "email"
-
-            [actions.changes]
-            name = "email_address"
-
-        [[actions]]
-        type = "add_index"
-        table = "users"
-
-            [actions.index]
-            name = "users_email_idx"
-            columns = [{ expression = "lower(email)" }]
-        "#,
-    );
-
-    test.after_completion(|db| {
-        let definition = get_index_definition(db, "users_email_idx");
-        assert!(
-            definition.contains("lower(email_address)"),
-            "expected the index to follow the rename, got: {}",
-            definition
-        );
-    });
-
-    test.run();
-}
-
 fn get_index_definition(db: &mut postgres::Client, index_name: &str) -> String {
     db.query(
         "

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -702,57 +702,6 @@ fn add_index_with_expression_to_renamed_column() {
     test.run();
 }
 
-#[test]
-fn add_index_with_expression_to_replaced_column() {
-    let mut test = Test::new("Add expression index to a column being replaced");
-
-    test.first_migration(
-        r#"
-        name = "create_users_table"
-
-        [[actions]]
-        type = "create_table"
-        name = "users"
-        primary_key = ["id"]
-
-            [[actions.columns]]
-            name = "id"
-            type = "INTEGER"
-
-            [[actions.columns]]
-            name = "email"
-            type = "TEXT"
-        "#,
-    );
-
-    // Altering the column replaces it with a new one and drops the original on
-    // completion, which would take the index with it. The migration must be rejected
-    // rather than silently losing the index.
-    test.second_migration(
-        r#"
-        name = "lowercase_email_and_index_it"
-
-        [[actions]]
-        type = "alter_column"
-        table = "users"
-        column = "email"
-        up = "LOWER(email)"
-        down = "email"
-
-        [[actions]]
-        type = "add_index"
-        table = "users"
-
-            [actions.index]
-            name = "users_email_idx"
-            columns = [{ expression = "lower(email)" }]
-        "#,
-    );
-
-    test.expect_failure();
-    test.run();
-}
-
 fn get_index_definition(db: &mut postgres::Client, index_name: &str) -> String {
     db.query(
         "

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::Test;
+use common::{assert_invalid_sql, Test};
 
 #[test]
 fn add_index() {
@@ -220,4 +220,454 @@ fn add_index_with_type() {
     });
 
     test.run();
+}
+
+#[test]
+fn add_index_invalid_expression_sql() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "add_index"
+        table = "users"
+        [actions.index]
+        name = "name_idx"
+        columns = [{ expression = "INVALID $$$ SYNTAX" }]
+        "#,
+    );
+}
+
+#[test]
+fn add_index_invalid_where_sql() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "add_index"
+        table = "users"
+        [actions.index]
+        name = "name_idx"
+        columns = ["name"]
+        where = "INVALID $$$ SYNTAX"
+        "#,
+    );
+}
+
+#[test]
+fn add_index_keeps_column_order() {
+    let mut test = Test::new("Add index with multiple columns");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "first_name"
+            type = "TEXT"
+
+            [[actions.columns]]
+            name = "last_name"
+            type = "TEXT"
+        "#,
+    );
+
+    // The index columns are declared in the opposite order to the table columns
+    test.second_migration(
+        r#"
+        name = "add_users_name_index"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "name_idx"
+            columns = ["last_name", "first_name"]
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        let definition = get_index_definition(db, "name_idx");
+        assert!(
+            definition.contains("(last_name, first_name)"),
+            "expected index columns to be in the declared order, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_with_direction_and_nulls() {
+    let mut test = Test::new("Add index with sort order");
+
+    test.first_migration(
+        r#"
+        name = "create_posts_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "posts"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "audience"
+            type = "TEXT"
+
+            [[actions.columns]]
+            name = "content_updated_at"
+            type = "TIMESTAMP"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_posts_keyset_index"
+
+        [[actions]]
+        type = "add_index"
+        table = "posts"
+
+            [actions.index]
+            name = "posts_keyset_idx"
+            columns = [
+                "audience",
+                { column = "content_updated_at", direction = "DESC", nulls = "LAST" },
+                "id",
+            ]
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        let definition = get_index_definition(db, "posts_keyset_idx");
+        assert!(
+            definition.contains("(audience, content_updated_at DESC NULLS LAST, id)"),
+            "expected index to use the declared sort order, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_partial() {
+    let mut test = Test::new("Add partial index");
+
+    test.first_migration(
+        r#"
+        name = "create_posts_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "posts"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "is_public"
+            type = "BOOLEAN"
+
+            [[actions.columns]]
+            name = "shared_to_community"
+            type = "BOOLEAN"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_posts_community_index"
+
+        [[actions]]
+        type = "add_index"
+        table = "posts"
+
+            [actions.index]
+            name = "posts_community_idx"
+            columns = ["id"]
+            where = "is_public AND shared_to_community"
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        let definition = get_index_definition(db, "posts_community_idx");
+        assert!(
+            definition.contains("WHERE (is_public AND shared_to_community)"),
+            "expected index to be partial, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_with_expression() {
+    let mut test = Test::new("Add expression index");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_users_email_index"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_email_idx"
+            unique = true
+            columns = [{ expression = "lower(email)" }]
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        let definition = get_index_definition(db, "users_email_idx");
+        assert!(
+            definition.contains("lower(email)"),
+            "expected an expression index, got: {}",
+            definition
+        );
+        assert!(
+            definition.contains("CREATE UNIQUE INDEX"),
+            "expected index to be unique, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_to_renamed_table() {
+    let mut test = Test::new("Add index to table renamed in the same migration");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+        "#,
+    );
+
+    // The index is added to the table using its new name, which doesn't exist in the
+    // database until the migration is completed
+    test.second_migration(
+        r#"
+        name = "rename_users_to_customers"
+
+        [[actions]]
+        type = "rename_table"
+        table = "users"
+        new_name = "customers"
+
+        [[actions]]
+        type = "add_index"
+        table = "customers"
+
+            [actions.index]
+            name = "customers_name_idx"
+            columns = ["name"]
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        // The index is created on the table under its current, real name
+        let definition = get_index_definition(db, "customers_name_idx");
+        assert!(
+            definition.contains("ON public.users"),
+            "expected index to be created on the real table, got: {}",
+            definition
+        );
+    });
+
+    test.after_completion(|db| {
+        let definition = get_index_definition(db, "customers_name_idx");
+        assert!(
+            definition.contains("ON public.customers"),
+            "expected index to follow the table rename, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_to_migrating_column() {
+    let mut test = Test::new("Add index to column added in the same migration");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    // Plain column references can be rewritten to the temporary column, so indexing a
+    // column which is being added in the same migration is fine
+    test.second_migration(
+        r#"
+        name = "add_users_name_column_and_index"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+
+            [actions.column]
+            name = "name"
+            type = "TEXT"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_name_idx"
+            columns = ["name"]
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        // The index is created on the temporary column
+        let definition = get_index_definition(db, "users_name_idx");
+        assert!(
+            definition.contains("__reshape"),
+            "expected index to be created on the temporary column, got: {}",
+            definition
+        );
+    });
+
+    test.after_completion(|db| {
+        // Once completed, the index follows the column to its final name
+        let definition = get_index_definition(db, "users_name_idx");
+        assert!(
+            definition.contains("(name)"),
+            "expected index to follow the column rename, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_with_expression_to_migrating_table() {
+    let mut test = Test::new("Add expression index while a column is being migrated");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    // Reshape can't rewrite the expression to reference the temporary column backing
+    // "name", so the migration should be rejected rather than create a broken index
+    test.second_migration(
+        r#"
+        name = "add_users_name_column_and_email_index"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+
+            [actions.column]
+            name = "name"
+            type = "TEXT"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_email_idx"
+            columns = [{ expression = "lower(email)" }]
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+fn get_index_definition(db: &mut postgres::Client, index_name: &str) -> String {
+    db.query(
+        "
+        SELECT pg_get_indexdef(pg_class.oid) AS definition
+        FROM pg_catalog.pg_class
+        JOIN pg_catalog.pg_namespace ON pg_class.relnamespace = pg_namespace.oid
+        WHERE pg_class.relname = $1 AND pg_namespace.nspname = 'public'
+        ",
+        &[&index_name],
+    )
+    .unwrap()
+    .first()
+    .map(|row| row.get("definition"))
+    .unwrap_or_else(|| panic!("expected index {} to exist", index_name))
 }

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -575,8 +575,8 @@ fn add_index_to_migrating_column() {
 }
 
 #[test]
-fn add_index_with_expression_to_migrating_table() {
-    let mut test = Test::new("Add expression index while a column is being migrated");
+fn add_index_with_expression_alongside_a_column_migration() {
+    let mut test = Test::new("Add expression index while another column is being migrated");
 
     test.first_migration(
         r#"
@@ -597,19 +597,147 @@ fn add_index_with_expression_to_migrating_table() {
         "#,
     );
 
-    // Reshape can't rewrite the expression to reference the temporary column backing
-    // "name", so the migration should be rejected rather than create a broken index
+    // The index doesn't reference the column being added, so it is unaffected by it
     test.second_migration(
         r#"
-        name = "add_users_name_column_and_email_index"
+        name = "add_nickname_column_and_email_index"
 
         [[actions]]
         type = "add_column"
         table = "users"
 
             [actions.column]
-            name = "name"
+            name = "nickname"
             type = "TEXT"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_email_idx"
+            columns = [{ expression = "lower(email)" }]
+            where = "email IS NOT NULL"
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        let definition = get_index_definition(db, "users_email_idx");
+        assert!(
+            definition.contains("lower(email)"),
+            "expected an expression index, got: {}",
+            definition
+        );
+    });
+
+    test.after_completion(|db| {
+        // The index must survive the column being renamed to its final name
+        let definition = get_index_definition(db, "users_email_idx");
+        assert!(
+            definition.contains("lower(email)"),
+            "expected the index to survive completion, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_with_expression_to_renamed_column() {
+    let mut test = Test::new("Add expression index to renamed column");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    // A rename keeps the same underlying column, so the index follows it and the
+    // expression is written against the column's current, real name
+    test.second_migration(
+        r#"
+        name = "rename_email_and_index_it"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "email"
+
+            [actions.changes]
+            name = "email_address"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_email_idx"
+            columns = [{ expression = "lower(email)" }]
+        "#,
+    );
+
+    test.after_completion(|db| {
+        let definition = get_index_definition(db, "users_email_idx");
+        assert!(
+            definition.contains("lower(email_address)"),
+            "expected the index to follow the rename, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_with_expression_to_replaced_column() {
+    let mut test = Test::new("Add expression index to a column being replaced");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    // Altering the column replaces it with a new one and drops the original on
+    // completion, which would take the index with it. The migration must be rejected
+    // rather than silently losing the index.
+    test.second_migration(
+        r#"
+        name = "lowercase_email_and_index_it"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "email"
+        up = "LOWER(email)"
+        down = "email"
 
         [[actions]]
         type = "add_index"


### PR DESCRIPTION
`add_index` could only create an index over a plain list of columns, so anything using a `WHERE` predicate, an explicit sort order or an expression had to be written as a `custom` migration.

## New index features

Each entry in `columns` is now either a plain column name, a table with a `column` plus optional `direction`/`nulls`, or a table with an `expression`. The index takes an optional `where` predicate:

```toml
[[actions]]
type = "add_index"
table = "posts"

    [actions.index]
    name = "posts_keyset_idx"
    columns = [
        "audience",
        { column = "content_updated_at", direction = "DESC", nulls = "LAST" },
        "id",
    ]
    where = "is_public AND shared_to_community"
```

```toml
    [actions.index]
    name = "users_email_idx"
    unique = true
    columns = [{ expression = "lower(email)" }]
```

Plain column references are resolved through the schema, so indexing a column added or altered earlier in the same migration correctly targets the temporary column and follows it to its final name. Expressions and predicates are passed to Postgres as written, and are not run through `validate_sql` — malformed SQL is reported by Postgres when the migration is applied.

## Two correctness bugs fixed

**Index column order was wrong.** The columns were produced by filtering the table's columns (`table.columns.iter().filter(|c| index.columns.contains(&c.name))`), so the index used the table's ordinal order rather than the declared order. An index declared on `["last_name", "first_name"]` silently became an index on `(first_name, last_name)` — which matters for keyset indexes, where column order is the whole point. Confirmed against the previous code:

```
expected index columns to be in the declared order,
got: CREATE INDEX name_idx ON public.users USING btree (first_name, last_name)
```

Columns are now resolved one at a time in declared order. As a side effect, a column name that doesn't exist is no longer silently dropped from the index — Postgres now reports it.

**Renamed tables broke.** `CREATE INDEX ... ON "{table}"` used `self.table` from the migration file rather than the `real_name` resolved through the schema it had just looked up, so adding an index to a table renamed earlier in the same migration failed. Confirmed against the previous code:

```
failed to Adding index "customers_name_idx" to table "customers"
  0: failed to create index
```

## Tests

- `add_index_keeps_column_order` and `add_index_to_renamed_table` — regression tests for the two bugs above, both verified to fail against the previous implementation.
- `add_index_with_direction_and_nulls`, `add_index_partial`, `add_index_with_expression` — the new features, asserted via `pg_get_indexdef`.
- `add_index_to_migrating_column` — a plain column reference to a column added in the same migration indexes the temporary column, then follows it to its final name on completion.
- `add_index_with_expression_alongside_a_column_migration` — an expression index alongside an unrelated `add_column`, surviving completion.

## Follow-up: expressions have no way to name a column being changed

Plain `columns` entries are resolved through the schema, so you write the name your application will use *after* the migration and the index follows the column to its final name. Expressions and `where` predicates are not resolved — they go to Postgres as written and therefore name the *real* column.

That means the two halves of the same action can need different names for the same column. With an `alter_column` renaming `email` to `email_address` in the same migration, `columns = ["email_address"]` works, while an expression has to say `lower(email)`; `lower(email_address)` fails with `column "email_address" does not exist`.

The old-name form does work today, because a name-only `alter_column` short-circuits and renames the column in place, leaving `attnum` untouched so Postgres rewrites the index expression itself. I'm deliberately not covering it with a test, since referring to a column by a name the migration has already changed isn't a pattern worth encoding until there's a way to use the new one. The docs now warn against referencing a column that is being altered or renamed.

## Follow-up: alter_column loses indices it can't express

Not addressed here, but found while working on this and worth its own fix. `alter_column` carries indices across a column change by rebuilding them from `get_index_columns` as `CREATE INDEX ... USING {type} ({columns})`, which drops everything else about the index. Measured on `main`, with a pre-existing index created by a `custom` migration:

| Index before `alter_column` | After |
|---|---|
| `(lower(email))` | gone — `get_indices_for_column` can't even see it, since `indkey` holds `0` for expression entries |
| `(email) WHERE is_active` | `(email)` — predicate silently dropped |
| `(email DESC NULLS LAST)` | `(email)` — sort order silently dropped |
| `UNIQUE (email) WHERE is_active` | fails loudly, but only when duplicates already exist |

This is independent of this PR and applies to any such index however it was created. It becomes easier to hit once `add_index` can create these natively, so it's worth fixing before or soon after this lands.

## Not included

`if_not_exists` was left out deliberately. `abort` drops the index by name, so an idempotent create would let an abort delete an index that existed before the migration ran. Making it safe needs a way for `abort` to know whether the index was actually created, which is a separate change.

Docs updated in `src/docs/actions/add-index.md` and the README. Full suite passes and `cargo clippy -- -D warnings` is clean.
