### PR TITLE
Support comments on tables and columns

### DIFF
--- a/src/docs/actions/add-column.md
+++ b/src/docs/actions/add-column.md
@@ -16,6 +16,7 @@ up = "expression"             # Optional: SQL expression or update config
     nullable = true           # Optional: default true
     default = "expression"    # Optional: SQL default
     generated = "clause"      # Optional: generation clause
+    comment = "description"   # Optional: comment on the column
 ```
 
 ### Complex Up Transformation
@@ -37,6 +38,7 @@ where = "join_condition"
 | `column.nullable` | boolean | No | Allow NULL (default: true) |
 | `column.default` | string | No | SQL default expression |
 | `column.generated` | string | No | Generation clause |
+| `column.comment` | string | No | Comment stored on the column |
 | `up` | string/object | No | Value transformation |
 
 ## Examples

--- a/src/docs/actions/create-table.md
+++ b/src/docs/actions/create-table.md
@@ -9,6 +9,7 @@ Create a new table in the database.
 type = "create_table"
 name = "table_name"           # Required: name of the table
 primary_key = ["id"]          # Required: primary key column(s)
+comment = "description"       # Optional: comment on the table
 
     [[actions.columns]]       # Required: at least one column
     name = "column_name"
@@ -16,6 +17,7 @@ primary_key = ["id"]          # Required: primary key column(s)
     nullable = true           # Optional: default true
     default = "expression"    # Optional: SQL expression
     generated = "clause"      # Optional: generation clause
+    comment = "description"   # Optional: comment on the column
 
     [[actions.foreign_keys]]  # Optional: foreign key constraints
     columns = ["col"]
@@ -43,6 +45,7 @@ primary_key = ["id"]          # Required: primary key column(s)
 | `nullable` | boolean | No | Allow NULL values (default: true) |
 | `default` | string | No | SQL expression for default value |
 | `generated` | string | No | Generation clause (e.g., "ALWAYS AS IDENTITY") |
+| `comment` | string | No | Comment stored on the column |
 
 ## Foreign Key Fields
 
@@ -93,6 +96,30 @@ primary_key = ["id"]
     type = "TIMESTAMPTZ"
     default = "NOW()"
 ```
+
+### Documented Table
+
+```toml
+[[actions]]
+type = "create_table"
+name = "users"
+primary_key = ["id"]
+comment = "People who can sign in"
+
+    [[actions.columns]]
+    name = "id"
+    type = "INTEGER"
+    generated = "ALWAYS AS IDENTITY"
+
+    [[actions.columns]]
+    name = "email"
+    type = "TEXT"
+    nullable = false
+    comment = "Primary contact address"
+```
+
+Comments are also copied onto the views Reshape creates for each migration, so they
+stay visible to applications and tooling which introspect the schema they connect to.
 
 ### Table with Foreign Key
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use crate::{
-    migrations::{Migration, MigrationContext},
+    migrations::{quote_string_literal, Migration, MigrationContext},
     schema::Schema,
 };
 
@@ -601,6 +603,75 @@ fn create_view_for_table(db: &mut impl Conn, table: &Table, schema: &str) -> any
         columns = select_columns.join(","),
     ))
     .with_context(|| format!("failed to create view for table {}", table.name))?;
+
+    copy_comments_to_view(db, table, schema)?;
+
+    Ok(())
+}
+
+// Copies the comments on a table and its columns onto the view which encapsulates it.
+// Applications and tooling introspect the migration schema rather than the underlying
+// table, so without this the comments would be invisible to them.
+fn copy_comments_to_view(db: &mut impl Conn, table: &Table, schema: &str) -> anyhow::Result<()> {
+    let table_comment: Option<String> = db
+        .query(&format!(
+            r#"
+            SELECT obj_description('public."{table_name}"'::regclass) AS comment
+            "#,
+            table_name = table.real_name,
+        ))
+        .with_context(|| format!("failed to get comment for table {}", table.real_name))?
+        .first()
+        .and_then(|row| row.get::<'_, _, Option<String>>("comment"));
+
+    if let Some(comment) = table_comment {
+        db.run(&format!(
+            r#"
+            COMMENT ON VIEW {schema}."{view_name}" IS {comment}
+            "#,
+            schema = schema,
+            view_name = table.name,
+            comment = quote_string_literal(&comment),
+        ))
+        .with_context(|| format!("failed to set comment for view {}", table.name))?;
+    }
+
+    let column_comments: HashMap<String, String> = db
+        .query(&format!(
+            r#"
+            SELECT attname AS name, col_description(attrelid, attnum) AS comment
+            FROM pg_attribute
+            WHERE attrelid = 'public."{table_name}"'::regclass
+                AND attnum > 0
+                AND NOT attisdropped
+                AND col_description(attrelid, attnum) IS NOT NULL
+            "#,
+            table_name = table.real_name,
+        ))
+        .with_context(|| format!("failed to get column comments for table {}", table.real_name))?
+        .iter()
+        .map(|row| (row.get("name"), row.get("comment")))
+        .collect();
+
+    for column in &table.columns {
+        if let Some(comment) = column_comments.get(&column.real_name) {
+            db.run(&format!(
+                r#"
+                COMMENT ON COLUMN {schema}."{view_name}"."{column_name}" IS {comment}
+                "#,
+                schema = schema,
+                view_name = table.name,
+                column_name = column.name,
+                comment = quote_string_literal(comment),
+            ))
+            .with_context(|| {
+                format!(
+                    "failed to set comment for column {} on view {}",
+                    column.name, table.name
+                )
+            })?;
+        }
+    }
 
     Ok(())
 }

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -1,4 +1,4 @@
-use super::{common, validate_sql_expression, Action, Column, MigrationContext};
+use super::{common, quote_string_literal, validate_sql_expression, Action, Column, MigrationContext};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -105,6 +105,20 @@ impl Action for AddColumn {
             definition = definition_parts.join(" "),
         );
         db.run(&query).context("failed to add column")?;
+
+        // Set the comment on the temporary column. Comments follow the column, so it
+        // will still be there once the column is renamed to its final name.
+        if let Some(comment) = &self.column.comment {
+            db.run(&format!(
+                r#"
+                COMMENT ON COLUMN "{table}"."{column}" IS {comment}
+                "#,
+                table = self.table,
+                column = temp_column_name,
+                comment = quote_string_literal(comment),
+            ))
+            .context("failed to set column comment")?;
+        }
 
         let declarations: Vec<String> = table
             .columns

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -13,6 +13,7 @@ pub struct Column {
     pub nullable: bool,
     pub default: Option<String>,
     pub generated: Option<String>,
+    pub comment: Option<String>,
 }
 
 fn nullable_default() -> bool {

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::{
     common::{Check, ForeignKey},
-    validate_sql_expression, Action, Column, MigrationContext,
+    quote_string_literal, validate_sql_expression, Action, Column, MigrationContext,
 };
 use crate::{
     db::{Conn, Transaction},
@@ -23,6 +23,8 @@ pub struct CreateTable {
 
     #[serde(default)]
     pub checks: Vec<Check>,
+
+    pub comment: Option<String>,
 
     pub up: Option<Transformation>,
 }
@@ -124,6 +126,31 @@ impl Action for CreateTable {
             definition = definition_rows.join(",\n"),
         );
         db.run(query).context("failed to create table")?;
+
+        if let Some(comment) = &self.comment {
+            db.run(&format!(
+                r#"
+                COMMENT ON TABLE "{name}" IS {comment}
+                "#,
+                name = self.name,
+                comment = quote_string_literal(comment),
+            ))
+            .context("failed to set table comment")?;
+        }
+
+        for column in &self.columns {
+            if let Some(comment) = &column.comment {
+                db.run(&format!(
+                    r#"
+                    COMMENT ON COLUMN "{table}"."{column}" IS {comment}
+                    "#,
+                    table = self.name,
+                    column = column.name,
+                    comment = quote_string_literal(comment),
+                ))
+                .context("failed to set column comment")?;
+            }
+        }
 
         if let Some(Transformation {
             table: from_table,

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -10,6 +10,13 @@ pub fn validate_sql_statement(sql: &str) -> Result<(), String> {
     pg_query::parse(sql).map(|_| ()).map_err(|e| e.to_string())
 }
 
+/// Quote a value so it can be used as an SQL string literal.
+///
+/// Used for statements which don't accept query parameters, such as `COMMENT ON`.
+pub fn quote_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
 /// Validate an SQL expression by wrapping it in SELECT
 pub fn validate_sql_expression(expr: &str) -> Result<(), String> {
     let wrapped = format!("SELECT ({})", expr);

--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{assert_invalid_sql, Test};
+use common::{assert_invalid_sql, get_column_comment, Test};
 
 #[test]
 fn add_column_invalid_up_sql() {
@@ -425,6 +425,65 @@ fn add_column_with_complex_up() {
             .map(|row| row.get("email"))
             .unwrap();
         assert_eq!("test2@example.com", email);
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_column_with_comment() {
+    let mut test = Test::new("Add column with comment");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_users_name_column"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+
+            [actions.column]
+            name = "name"
+            type = "TEXT"
+            comment = "The user's display name"
+        "#,
+    );
+
+    test.intermediate(|_, new_db| {
+        // Ensure the comment is visible through the new schema's view while the
+        // column is still backed by a temporary column
+        assert_eq!(
+            Some("The user's display name".to_string()),
+            get_column_comment(new_db, "users", "name")
+        );
+    });
+
+    test.after_completion(|db| {
+        // Ensure the comment follows the column when it is renamed to its final name
+        assert_eq!(
+            Some("The user's display name".to_string()),
+            get_column_comment(db, "public.users", "name")
+        );
+    });
+
+    test.after_abort(|db| {
+        // Ensure the column, and with it the comment, was removed
+        assert_eq!(None, get_column_comment(db, "public.users", "name"));
     });
 
     test.run();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,6 +9,35 @@ pub fn assert_invalid_sql(toml: &str) {
     assert!(!errors.is_empty(), "expected SQL validation to fail");
 }
 
+// Looks up the comment on a table or view. The name is resolved using the connection's
+// search path, so an unqualified name will find the view in the current migration schema.
+#[allow(dead_code)]
+pub fn get_comment(db: &mut Client, relation: &str) -> Option<String> {
+    db.query(
+        "SELECT obj_description($1::text::regclass) AS comment",
+        &[&relation],
+    )
+    .unwrap()
+    .first()
+    .and_then(|row| row.get("comment"))
+}
+
+// Looks up the comment on a column of a table or view
+#[allow(dead_code)]
+pub fn get_column_comment(db: &mut Client, relation: &str, column: &str) -> Option<String> {
+    db.query(
+        "
+        SELECT col_description(attrelid, attnum) AS comment
+        FROM pg_attribute
+        WHERE attrelid = $1::text::regclass AND attname = $2
+        ",
+        &[&relation, &column],
+    )
+    .unwrap()
+    .first()
+    .and_then(|row| row.get("comment"))
+}
+
 pub struct Test<'a> {
     name: &'a str,
     reshape: Reshape,

--- a/tests/create_table.rs
+++ b/tests/create_table.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{assert_invalid_sql, Test};
+use common::{assert_invalid_sql, get_column_comment, get_comment, Test};
 use reshape::migrations::Migration;
 
 #[test]
@@ -538,6 +538,61 @@ fn create_table_with_checks_during_migration() {
             .unwrap()
             .is_empty();
         assert!(!table_exists, "expected table to have been removed");
+    });
+
+    test.run();
+}
+
+#[test]
+fn create_table_with_comments() {
+    let mut test = Test::new("Create table with comments");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+        comment = "People who can sign in"
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+            comment = "Primary contact address. Don't share it"
+        "#,
+    );
+
+    test.after_first(|db| {
+        // Ensure the comments were set on the underlying table
+        assert_eq!(
+            Some("People who can sign in".to_string()),
+            get_comment(db, "public.users")
+        );
+        assert_eq!(
+            Some("Primary contact address. Don't share it".to_string()),
+            get_column_comment(db, "public.users", "email")
+        );
+
+        // Ensure the comments are also visible through the view the application uses.
+        // The connection's search path points at the migration schema, so the
+        // unqualified name resolves to the view.
+        assert_eq!(
+            Some("People who can sign in".to_string()),
+            get_comment(db, "users")
+        );
+        assert_eq!(
+            Some("Primary contact address. Don't share it".to_string()),
+            get_column_comment(db, "users", "email")
+        );
+
+        // Ensure a column without a comment doesn't get one
+        assert_eq!(None, get_column_comment(db, "users", "id"));
     });
 
     test.run();


### PR DESCRIPTION
There is currently no way to document a table or column, so every table and most columns need a `custom` block just to run `COMMENT ON`.

## Changes

`create_table` takes a `comment` for the table, and `common::Column` takes a `comment` which is honoured by both `create_table` and `add_column`:

```toml
[[actions]]
type = "create_table"
name = "users"
primary_key = ["id"]
comment = "People who can sign in"

    [[actions.columns]]
    name = "email"
    type = "TEXT"
    comment = "Primary contact address"
```

Comment text is quoted through a shared `quote_string_literal` helper, since `COMMENT ON` is a utility statement and doesn't accept query parameters — apostrophes in comment text are handled correctly and covered by a test.

For `add_column` the comment is set on the temporary column during the start phase. Comments are attached to the column itself, so it follows the column when it is renamed to its final name on completion.

Per your note I did not add a standalone `set_comment` action — comments are declared on the resource in the migration that creates it.

## Comments are copied onto the migration views

This is the part worth a look. Your application connects to the `migration_<name>` schema and talks to views, not the underlying tables, and `obj_description`/`col_description` on a view return the *view's* comment. Without propagation the comments would be written to the database but invisible to anything introspecting the schema it is actually connected to — which matters for tooling like PostgREST.

So `create_view_for_table` now copies the comments from the underlying table and its columns onto the view after creating it. It reads them from the catalog rather than from the action, which means comments set by a `custom` action get copied too.

## Scope

Tables and columns only, which is what `COMMENT ON` is being used for in practice. Indexes, constraints and enums can still be commented with a `custom` action; happy to extend if useful.

## Tests

- `create_table_with_comments` — comments on the table and a column, asserted both on the underlying `public.users` and through the migration view, including an apostrophe in the comment text, plus a check that a column without a comment doesn't get one.
- `add_column_with_comment` — visible through the new schema's view while the column is still backed by a temporary column, survives the rename on completion, and gone after abort.

Docs updated in `src/docs/actions/{create-table,add-column}.md`. The README is deliberately left alone.

Full suite passes and `cargo clippy -- -D warnings` is clean.
