### PR TITLE
fix(migrations): resume failed completion safely

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ fn complete(db: &mut DbConn, state: &mut State) -> anyhow::Result<()> {
             // We won't save this new state until after the action has completed.
             state.completing(
                 remaining_migrations.clone(),
-                migration_index + 1,
+                migration_index,
                 action_index + 1,
             );
 

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -186,6 +186,7 @@ pub struct Index {
     pub oid: u32,
     pub unique: bool,
     pub index_type: String,
+    pub constraint_owned: bool,
 }
 
 pub fn get_indices_for_column(
@@ -200,7 +201,12 @@ pub fn get_indices_for_column(
                 i.relname AS name,
                 i.oid AS oid,
                 ix.indisunique AS unique,
-                am.amname AS type
+                am.amname AS type,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_constraint con
+                    WHERE con.conindid = i.oid
+                ) AS constraint_owned
             FROM pg_index ix
             JOIN pg_class t ON t.oid = ix.indrelid
             JOIN pg_class i ON i.oid = ix.indexrelid
@@ -221,6 +227,7 @@ pub fn get_indices_for_column(
             oid: row.get("oid"),
             unique: row.get("unique"),
             index_type: row.get("type"),
+            constraint_owned: row.get("constraint_owned"),
         })
         .collect();
 

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -331,6 +331,12 @@ impl Action for RemoveColumn {
             .context("failed getting column indices")?;
 
         for index in indices {
+            // PostgreSQL does not allow dropping an index that backs a constraint.
+            // Dropping the column removes both the constraint and its index.
+            if index.constraint_owned {
+                continue;
+            }
+
             db.run(&format!(
                 "
                 DROP INDEX CONCURRENTLY IF EXISTS {name}

--- a/tests/failure.rs
+++ b/tests/failure.rs
@@ -1,5 +1,8 @@
 mod common;
 use common::Test;
+use postgres::Client;
+use postgres_native_tls::MakeTlsConnector;
+use reshape::{migrations::Migration, Reshape};
 
 #[test]
 fn invalid_migration() {
@@ -48,4 +51,72 @@ fn invalid_migration() {
 
     test.expect_failure();
     test.run();
+}
+
+#[test]
+fn completion_resumes_at_failed_action() {
+    let connection_string = std::env::var("POSTGRES_CONNECTION_STRING")
+        .unwrap_or("postgres://postgres:postgres@localhost/reshape_test".to_string());
+    let tls_connector = native_tls::TlsConnector::new().unwrap();
+    let mut db = Client::connect(
+        &connection_string,
+        MakeTlsConnector::new(tls_connector),
+    )
+    .unwrap();
+    let mut reshape = Reshape::new(&connection_string).unwrap();
+
+    reshape.remove().unwrap();
+    db.batch_execute(
+        "
+        DROP TABLE IF EXISTS completion_before_retry;
+        DROP TABLE IF EXISTS completion_retry_gate;
+        DROP TABLE IF EXISTS completion_after_retry;
+        ",
+    )
+    .unwrap();
+
+    let migration: Migration = toml::from_str(
+        r#"
+        name = "completion_retry"
+
+        [[actions]]
+        type = "custom"
+        complete = "CREATE TABLE completion_before_retry (id INTEGER);"
+
+        [[actions]]
+        type = "custom"
+        complete = "INSERT INTO completion_retry_gate (id) VALUES (1);"
+
+        [[actions]]
+        type = "custom"
+        complete = "CREATE TABLE completion_after_retry (id INTEGER);"
+        "#,
+    )
+    .unwrap();
+
+    reshape.migrate(vec![migration]).unwrap();
+    assert!(reshape.complete().is_err());
+
+    db.batch_execute("CREATE TABLE completion_retry_gate (id INTEGER);")
+        .unwrap();
+    reshape.complete().unwrap();
+
+    let after_retry_exists: bool = db
+        .query_one(
+            "SELECT to_regclass('public.completion_after_retry') IS NOT NULL",
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert!(after_retry_exists, "expected completion to resume after failure");
+
+    db.batch_execute(
+        "
+        DROP TABLE completion_before_retry;
+        DROP TABLE completion_retry_gate;
+        DROP TABLE completion_after_retry;
+        ",
+    )
+    .unwrap();
+    reshape.remove().unwrap();
 }

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -181,6 +181,68 @@ fn remove_column_with_index() {
 }
 
 #[test]
+fn remove_column_with_unique_constraint() {
+    let mut test = Test::new("Remove column with unique constraint");
+
+    test.first_migration(
+        r#"
+        name = "create_user_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "remove_email_column"
+
+        [[actions]]
+        type = "remove_column"
+        table = "users"
+        column = "email"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query(
+            "ALTER TABLE public.users ADD CONSTRAINT users_email_unique UNIQUE (email)",
+        )
+        .unwrap();
+    });
+
+    test.after_completion(|db| {
+        let count: i64 = db
+            .query(
+                "
+                SELECT COUNT(*)
+                FROM pg_catalog.pg_constraint
+                WHERE conname = 'users_email_unique'
+                ",
+                &[],
+            )
+            .unwrap()
+            .first()
+            .map(|row| row.get(0))
+            .unwrap();
+
+        assert_eq!(0, count, "expected unique constraint to not exist");
+    });
+
+    test.run();
+}
+
+#[test]
 fn remove_column_with_complex_down() {
     let mut test = Test::new("Remove column complex");
 


### PR DESCRIPTION
# Fix: make failed migration completion resumable

## The problem

Completing a `remove_column` migration fails when the column participates in a `UNIQUE` constraint. Reshape discovers the constraint's backing index and issues `DROP INDEX CONCURRENTLY`, which PostgreSQL rejects because the index is owned by the constraint.

```text
ERROR: cannot drop index users_email_unique because constraint users_email_unique on table users requires it
HINT: You can drop constraint users_email_unique on table users instead.
```

After any completion action fails, retrying `complete` can also skip the rest of that migration. The saved checkpoint records `migration_index + 1` after each successful action, so a retry treats the entire current migration as already completed even though later actions never ran.

<details>
<summary><strong>Runtime behavior</strong> — where completion stopped</summary>

The migration START phase succeeds and exposes the schema without the removed column. During COMPLETE, Reshape enumerates every index containing that column and tries to drop each one directly. Standalone indexes can be dropped this way, but PostgreSQL protects indexes that implement table constraints. If an operator removes the blocker and retries completion, the incorrect checkpoint can then advance to idle without running that action or any later action in the migration.

</details>

## The fix

Index discovery now records whether an index is referenced by `pg_constraint.conindid`. `remove_column` continues to drop standalone indexes concurrently, but skips constraint-owned indexes. The subsequent `ALTER TABLE ... DROP COLUMN` removes constraints involving the column and their backing indexes using PostgreSQL's native dependency handling.

Completion checkpoints now retain the current migration index and advance only the action index. A retry therefore resumes at the failed action; after the final action, the existing completion transition still records the migration and returns to idle.

<details>
<summary><strong>Implementation</strong> — distinguishing index ownership</summary>

`get_indices_for_column` adds a correlated `EXISTS` query against `pg_constraint`. This preserves the complete index list for other migration actions while allowing `remove_column` to choose the correct cleanup path. Separately, the completion state now saves `(migration_index, action_index + 1)` rather than `(migration_index + 1, action_index + 1)`.

</details>

<details>
<summary><strong>Compatibility</strong> — behavior that remains unchanged</summary>

Standalone indexes are still removed with `DROP INDEX CONCURRENTLY` before the column is dropped. Other users of index discovery continue to receive all indexes, including unique and constraint-owned indexes; only `remove_column` skips the direct drop for constraint-owned entries.

Successful completion remains unchanged. The checkpoint correction only affects retries after interruption or failure, ensuring the current migration's remaining actions are not skipped.

</details>

## Test plan

- [x] Added an integration test that creates a unique constraint, removes its column, and verifies completion succeeds and the constraint is gone
- [x] Added an integration test that forces a middle completion action to fail, repairs its prerequisite, retries, and verifies the later action runs
- [x] Full PostgreSQL integration suite: 51 passed
- [x] `cargo clippy -- -D warnings`
- [x] `git diff --check`

## Risk and rollback

The index change delegates constraint cleanup to the same `ALTER TABLE ... DROP COLUMN` statement that already removes the column. The checkpoint change keeps retries within the current migration until all actions finish. Reverting either change restores the corresponding failure or skipped-action behavior.
