### PR TITLE
Add SQL validation for index expressions, partial index predicates and check constraints

### DIFF
--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -188,8 +188,7 @@ impl Action for AddIndex {
     fn validate_sql(&self) -> Vec<(String, String, String)> {
         let mut errors = vec![];
 
-        // Validate index expressions. Plain column names and sort options are not
-        // SQL expressions and don't need validation.
+        // Validate index expressions
         for (idx, column) in self.index.columns.iter().enumerate() {
             if let IndexColumn::Expression(spec) = column {
                 if let Err(e) = validate_sql_expression(&spec.expression) {

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -1,4 +1,4 @@
-use super::{Action, MigrationContext};
+use super::{validate_sql_expression, Action, MigrationContext};
 use crate::{
     db::{Conn, Transaction},
     schema::{Schema, Table},
@@ -183,5 +183,32 @@ impl Action for AddIndex {
         ))
         .context("failed to drop index")?;
         Ok(())
+    }
+
+    fn validate_sql(&self) -> Vec<(String, String, String)> {
+        let mut errors = vec![];
+
+        // Validate index expressions. Plain column names and sort options are not
+        // SQL expressions and don't need validation.
+        for (idx, column) in self.index.columns.iter().enumerate() {
+            if let IndexColumn::Expression(spec) = column {
+                if let Err(e) = validate_sql_expression(&spec.expression) {
+                    errors.push((
+                        format!("index.columns[{}].expression", idx),
+                        spec.expression.clone(),
+                        e,
+                    ));
+                }
+            }
+        }
+
+        // Validate partial index predicate
+        if let Some(predicate) = &self.index.r#where {
+            if let Err(e) = validate_sql_expression(predicate) {
+                errors.push(("index.where".to_string(), predicate.clone(), e));
+            }
+        }
+
+        errors
     }
 }

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -291,6 +291,17 @@ impl Action for CreateTable {
             // (e.g., "ALWAYS AS IDENTITY"), not a SQL expression
         }
 
+        // Validate check constraint expressions
+        for (idx, check) in self.checks.iter().enumerate() {
+            if let Err(e) = validate_sql_expression(&check.expression) {
+                errors.push((
+                    format!("checks[{}].expression", idx),
+                    check.expression.clone(),
+                    e,
+                ));
+            }
+        }
+
         // Validate transformation values
         if let Some(Transformation { values, .. }) = &self.up {
             for (key, value) in values {

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -1,5 +1,36 @@
 mod common;
-use common::Test;
+use common::{assert_invalid_sql, Test};
+
+#[test]
+fn add_index_invalid_expression_sql() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "add_index"
+        table = "users"
+        [actions.index]
+        name = "users_email_idx"
+        columns = [{ expression = "INVALID $$$ SYNTAX" }]
+        "#,
+    );
+}
+
+#[test]
+fn add_index_invalid_where_sql() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "add_index"
+        table = "users"
+        [actions.index]
+        name = "users_email_idx"
+        columns = ["email"]
+        where = "INVALID $$$ SYNTAX"
+        "#,
+    );
+}
 
 #[test]
 fn add_index() {

--- a/tests/create_table.rs
+++ b/tests/create_table.rs
@@ -23,6 +23,25 @@ fn create_table_invalid_default_sql() {
 }
 
 #[test]
+fn create_table_invalid_check_sql() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+        [[actions.columns]]
+        name = "id"
+        type = "INTEGER"
+        [[actions.checks]]
+        name = "id_positive"
+        expression = "INVALID $$$ SYNTAX"
+        "#,
+    );
+}
+
+#[test]
 fn create_table_invalid_up_values_sql() {
     assert_invalid_sql(
         r#"


### PR DESCRIPTION
## Summary

The recently added partial, expression and sorted indexes (#41) and CHECK constraints in `create_table` (#40) introduced new fields containing user-written SQL expressions which weren't covered by `validate_sql`. Invalid SQL in these fields would only be caught once the statement was run against the database, rather than by `reshape migration check` or before the action runs.

- `add_index`: implement `validate_sql`, covering every `{ expression = "..." }` entry in `index.columns` and the `index.where` predicate
- `create_table`: extend the existing `validate_sql` to cover `checks[].expression`

Fields that don't need validation and are left alone: `on_delete`/`on_update` and index `direction`/`nulls` are closed enums, and table/column `comment` values are string literals escaped via `quote_string_literal`.

## Test plan

- [x] New `add_index_invalid_expression_sql`, `add_index_invalid_where_sql` and `create_table_invalid_check_sql` tests fail validation as expected
- [x] Existing `add_index` and `create_table` suites pass
- [x] `cargo clippy -- -D warnings` clean