### PR TITLE
Bump pg_query to 6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ colored = "3"
 rand = "0.9"
 dotenv = "0.15.0"
 lexical-sort = "0.3.1"
-pg_query = "6"
+pg_query = "6.2"
 native-tls = { version = "0.2", features = ["vendored"] }
 postgres-native-tls = "0.5"


### PR DESCRIPTION
## Summary

Bumps `pg_query` from 6.1.1 to 6.2.0, which upgrades the bundled libpg_query to 17-6.2.2 and picks up newer Postgres 17 parser fixes. No API changes affect reshape.

## Test plan

- [x] Full test suite passes against a local Postgres
- [x] `cargo clippy -- -D warnings` clean