### PR TITLE
Rewrite column references in index expressions to real column names

### DIFF
--- a/src/docs/actions/add-index.md
+++ b/src/docs/actions/add-index.md
@@ -160,8 +160,7 @@ table = "documents"
 - Indexes are created concurrently to avoid blocking
 - The index is immediately available after the start phase
 - For unique indexes, existing data must not have duplicates
-- Expressions and `where` predicates are passed to Postgres as written rather than being
-  resolved by Reshape, so they reference the table's real columns. Avoid referencing a
-  column which is being altered or renamed in the same migration: `alter_column` replaces
-  the column rather than modifying it in place, so creating the index can fail, and an
-  index that is created may be dropped again when the migration is completed
+- Expressions and `where` predicates reference columns by their current names, just like
+  plain column entries. Columns which are added, altered or renamed earlier in the same
+  migration can be referenced by their new names and the index follows them when the
+  migration completes. Referencing a column which doesn't exist fails the migration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod docs;
 mod helpers;
 pub mod migrations;
 mod schema;
+mod sql;
 mod state;
 
 pub use crate::state::State;

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -2,6 +2,7 @@ use super::{Action, MigrationContext};
 use crate::{
     db::{Conn, Transaction},
     schema::{Schema, Table},
+    sql::rewrite_column_references,
 };
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -88,7 +89,9 @@ fn sort_definition(direction: &Option<Direction>, nulls: &Option<Nulls>) -> Stri
 }
 
 impl Index {
-    fn column_definitions(&self, table: &Table) -> Vec<String> {
+    // Expressions and predicates reference columns by their current names but the index
+    // is created on the real table, so they are rewritten to the real column names.
+    fn column_definitions(&self, table: &Table) -> anyhow::Result<Vec<String>> {
         self.columns
             .iter()
             .map(|column| {
@@ -100,17 +103,33 @@ impl Index {
                         &spec.nulls,
                     ),
                     IndexColumn::Expression(spec) => (
-                        format!("({})", spec.expression),
+                        format!(
+                            "({})",
+                            rewrite_column_references(&spec.expression, table).with_context(
+                                || format!("invalid index expression: {}", spec.expression)
+                            )?
+                        ),
                         &spec.direction,
                         &spec.nulls,
                     ),
                 };
 
-                format!("{} {}", target, sort_definition(direction, nulls))
+                Ok(format!("{} {}", target, sort_definition(direction, nulls))
                     .trim_end()
-                    .to_string()
+                    .to_string())
             })
             .collect()
+    }
+
+    fn where_definition(&self, table: &Table) -> anyhow::Result<String> {
+        match &self.r#where {
+            Some(predicate) => {
+                let rewritten = rewrite_column_references(predicate, table)
+                    .with_context(|| format!("invalid index predicate: {}", predicate))?;
+                Ok(format!("WHERE {rewritten}"))
+            }
+            None => Ok("".to_string()),
+        }
     }
 }
 
@@ -146,11 +165,7 @@ impl Action for AddIndex {
         } else {
             "".to_string()
         };
-        let where_def = if let Some(predicate) = &self.index.r#where {
-            format!("WHERE {predicate}")
-        } else {
-            "".to_string()
-        };
+        let where_def = self.index.where_definition(&table)?;
 
         db.run(&format!(
             r#"
@@ -158,7 +173,7 @@ impl Action for AddIndex {
 			"#,
             name = self.index.name,
             table = table.real_name,
-            columns = self.index.column_definitions(&table).join(", "),
+            columns = self.index.column_definitions(&table)?.join(", "),
         ))
         .context("failed to create index")?;
         Ok(())

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -5,22 +5,13 @@ use crate::{
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
-/// Validate a complete SQL statement using pg_query
-pub fn validate_sql_statement(sql: &str) -> Result<(), String> {
-    pg_query::parse(sql).map(|_| ()).map_err(|e| e.to_string())
-}
+pub use crate::sql::{validate_sql_expression, validate_sql_statement};
 
 /// Quote a value so it can be used as an SQL string literal.
 ///
 /// Used for statements which don't accept query parameters, such as `COMMENT ON`.
 pub fn quote_string_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
-}
-
-/// Validate an SQL expression by wrapping it in SELECT
-pub fn validate_sql_expression(expr: &str) -> Result<(), String> {
-    let wrapped = format!("SELECT ({})", expr);
-    pg_query::parse(&wrapped).map(|_| ()).map_err(|e| e.to_string())
 }
 
 // Re-export migration types

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,0 +1,441 @@
+//! Parsing of user-provided SQL, used to validate and rewrite the expressions found in
+//! migration files.
+
+use crate::schema::{Column, Table};
+use anyhow::anyhow;
+use pg_query::protobuf::Token;
+use serde_json::Value;
+
+/// Validate a complete SQL statement using pg_query
+pub fn validate_sql_statement(sql: &str) -> Result<(), String> {
+    pg_query::parse(sql).map(|_| ()).map_err(|e| e.to_string())
+}
+
+/// Validate an SQL expression by wrapping it in SELECT
+pub fn validate_sql_expression(expr: &str) -> Result<(), String> {
+    pg_query::parse(&wrap_expression(expr))
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// Rewrites the column references in an expression to point at the real columns backing
+/// the table. Columns are referenced by the names they currently have in the schema, but
+/// the columns they are backed by may have different names, for example a temporary
+/// column introduced by `alter_column` or a column which is renamed once the migration
+/// completes. The rewritten expression can be run directly against the real table.
+///
+/// Fails if the expression references a column or table which doesn't exist.
+pub fn rewrite_column_references(expression: &str, table: &Table) -> anyhow::Result<String> {
+    let wrapped = wrap_expression(expression);
+    let references = extract_column_references(&wrapped).map_err(|e| anyhow!(e))?;
+
+    let mut errors = Vec::new();
+    let mut resolutions = Vec::new();
+    for reference in references {
+        match resolve(&reference, table) {
+            Ok(Some(resolution)) => resolutions.push((reference, resolution)),
+            Ok(None) => {}
+            Err(error) => errors.push(error),
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(anyhow!(errors.join(", ")));
+    }
+
+    let rewritten = splice(&wrapped, &resolutions).map_err(|e| anyhow!(e))?;
+    Ok(unwrap_expression(&rewritten))
+}
+
+const EXPRESSION_PREFIX: &str = "SELECT (";
+const EXPRESSION_SUFFIX: &str = ")";
+
+fn wrap_expression(expression: &str) -> String {
+    format!("{EXPRESSION_PREFIX}{expression}{EXPRESSION_SUFFIX}")
+}
+
+fn unwrap_expression(wrapped: &str) -> String {
+    wrapped[EXPRESSION_PREFIX.len()..wrapped.len() - EXPRESSION_SUFFIX.len()].to_string()
+}
+
+/// A column reference found in an expression, for example `name` or `users.name`
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ColumnReference {
+    /// The dot-separated parts of the reference. Unquoted identifiers have already been
+    /// lowercased by the parser, matching how Postgres resolves them.
+    fields: Vec<String>,
+    /// Byte offset of the first field within the parsed SQL
+    location: usize,
+}
+
+/// Finds all column references in a SQL string.
+///
+/// pg_query's own node iterator only visits a subset of node types and misses references
+/// inside for example array constructors and subscripts. Instead we walk the serialized
+/// parse tree, which is complete. References inside subqueries are skipped as they belong
+/// to the subquery's own scope.
+fn extract_column_references(sql: &str) -> Result<Vec<ColumnReference>, String> {
+    let parsed = pg_query::parse(sql).map_err(|e| e.to_string())?;
+    let tree = serde_json::to_value(&parsed.protobuf).map_err(|e| e.to_string())?;
+
+    let mut references = Vec::new();
+    collect_column_references(&tree, &mut references);
+    references.sort_by_key(|reference| reference.location);
+
+    Ok(references)
+}
+
+fn collect_column_references(node: &Value, references: &mut Vec<ColumnReference>) {
+    match node {
+        Value::Object(fields) => {
+            if fields.contains_key("SubLink") {
+                return;
+            }
+
+            if let Some(column_ref) = fields.get("ColumnRef") {
+                if let Some(reference) = parse_column_ref(column_ref) {
+                    references.push(reference);
+                }
+                return;
+            }
+
+            for child in fields.values() {
+                collect_column_references(child, references);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_column_references(item, references);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_column_ref(node: &Value) -> Option<ColumnReference> {
+    let location = usize::try_from(node.get("location")?.as_i64()?).ok()?;
+
+    // Each field is either an identifier or a star. References containing a star, such
+    // as `users.*`, are not column references and are skipped.
+    let fields = node
+        .get("fields")?
+        .as_array()?
+        .iter()
+        .map(|field| Some(field.pointer("/node/String/sval")?.as_str()?.to_string()))
+        .collect::<Option<Vec<String>>>()?;
+
+    Some(ColumnReference { fields, location })
+}
+
+/// The column and table a reference resolves to, along with which of the reference's
+/// fields name them.
+struct Resolution<'a> {
+    table_field: Option<usize>,
+    table: &'a Table,
+    column_field: usize,
+    column: &'a Column,
+}
+
+/// Resolves a reference against a table. Returns `Ok(None)` for references which can't
+/// be checked, such as the `NEW` and `OLD` rows available in triggers.
+fn resolve<'a>(
+    reference: &ColumnReference,
+    table: &'a Table,
+) -> Result<Option<Resolution<'a>>, String> {
+    let fields = &reference.fields;
+
+    match fields.len() {
+        // Unqualified column, e.g. `name`
+        1 => {
+            let column = find_column(table, &fields[0])?;
+            Ok(Some(Resolution {
+                table_field: None,
+                table,
+                column_field: 0,
+                column,
+            }))
+        }
+        // Qualified column, e.g. `users.name` or `public.users.name`
+        2 | 3 => {
+            let qualifier_field = fields.len() - 2;
+            let column_field = fields.len() - 1;
+            let qualifier = &fields[qualifier_field];
+
+            if *qualifier == table.name {
+                let column = find_column(table, &fields[column_field])?;
+                return Ok(Some(Resolution {
+                    table_field: Some(qualifier_field),
+                    table,
+                    column_field,
+                    column,
+                }));
+            }
+
+            if qualifier == "new" || qualifier == "old" {
+                return Ok(None);
+            }
+
+            // A two-part reference can also be a field of a composite-typed column, e.g.
+            // `address.city`. In that case, the first part is the column reference.
+            if fields.len() == 2 {
+                if let Some(column) = table.get_column(qualifier) {
+                    return Ok(Some(Resolution {
+                        table_field: None,
+                        table,
+                        column_field: 0,
+                        column,
+                    }));
+                }
+            }
+
+            Err(format!("unknown table \"{}\"", qualifier))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn find_column<'a>(table: &'a Table, name: &str) -> Result<&'a Column, String> {
+    table.get_column(name).ok_or_else(|| {
+        format!(
+            "column \"{}\" does not exist on table \"{}\"",
+            name, table.name
+        )
+    })
+}
+
+/// Replaces the resolved table and column names in the SQL with their real names, leaving
+/// everything else untouched.
+fn splice(sql: &str, resolutions: &[(ColumnReference, Resolution)]) -> Result<String, String> {
+    let scanned = pg_query::scan(sql).map_err(|e| e.to_string())?;
+    let tokens: Vec<_> = scanned
+        .tokens
+        .iter()
+        .filter(|token| !matches!(token.token(), Token::SqlComment | Token::CComment))
+        .collect();
+
+    let mut replacements: Vec<(usize, usize, String)> = Vec::new();
+
+    for (reference, resolution) in resolutions {
+        let first = tokens
+            .iter()
+            .position(|token| token.start as usize == reference.location)
+            .ok_or_else(|| format!("failed to locate reference {}", reference.fields.join(".")))?;
+
+        // The fields of a reference are identifier tokens separated by dots
+        let field_token = |field: usize| -> Result<(usize, usize), String> {
+            let index = first + field * 2;
+            if field > 0 {
+                let separator = tokens.get(index - 1).map(|token| token.token());
+                if separator != Some(Token::Ascii46) {
+                    return Err(format!(
+                        "failed to locate reference {}",
+                        reference.fields.join(".")
+                    ));
+                }
+            }
+            tokens
+                .get(index)
+                .map(|token| (token.start as usize, token.end as usize))
+                .ok_or_else(|| format!("failed to locate reference {}", reference.fields.join(".")))
+        };
+
+        if let Some(table_field) = resolution.table_field {
+            let (start, end) = field_token(table_field)?;
+            replacements.push((start, end, quote_identifier(&resolution.table.real_name)));
+        }
+
+        let (start, end) = field_token(resolution.column_field)?;
+        replacements.push((start, end, quote_identifier(&resolution.column.real_name)));
+    }
+
+    replacements.sort_by_key(|(start, _, _)| *start);
+
+    let mut result = String::with_capacity(sql.len());
+    let mut position = 0;
+    for (start, end, replacement) in replacements {
+        result.push_str(&sql[position..start]);
+        result.push_str(&replacement);
+        position = end;
+    }
+    result.push_str(&sql[position..]);
+
+    Ok(result)
+}
+
+fn quote_identifier(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn column(name: &str, real_name: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            real_name: real_name.to_string(),
+            data_type: "TEXT".to_string(),
+            nullable: true,
+            default: None,
+        }
+    }
+
+    // A table where `status` is backed by a temporary column and `state` was renamed
+    // from `old_state`. `id` and `address` are unchanged.
+    fn table() -> Table {
+        Table {
+            name: "users".to_string(),
+            real_name: "users".to_string(),
+            columns: vec![
+                column("id", "id"),
+                column("status", "__reshape_0_0_status"),
+                column("state", "old_state"),
+                column("address", "address"),
+            ],
+        }
+    }
+
+    fn rewrite(expression: &str) -> String {
+        rewrite_column_references(expression, &table()).unwrap()
+    }
+
+    fn rewrite_error(expression: &str) -> String {
+        rewrite_column_references(expression, &table())
+            .unwrap_err()
+            .to_string()
+    }
+
+    #[test]
+    fn rewrites_columns_to_real_names() {
+        assert_eq!(rewrite("status"), r#""__reshape_0_0_status""#);
+        assert_eq!(rewrite("state"), r#""old_state""#);
+        assert_eq!(rewrite("id"), r#""id""#);
+    }
+
+    #[test]
+    fn preserves_formatting_and_rest_of_expression() {
+        assert_eq!(
+            rewrite("status =   'active' AND  id > 10"),
+            r#""__reshape_0_0_status" =   'active' AND  "id" > 10"#
+        );
+        assert_eq!(
+            rewrite("coalesce(lower(status), 'none')"),
+            r#"coalesce(lower("__reshape_0_0_status"), 'none')"#
+        );
+    }
+
+    #[test]
+    fn rewrites_qualified_references() {
+        assert_eq!(rewrite("users.status"), r#""users"."__reshape_0_0_status""#);
+        assert_eq!(
+            rewrite("public.users.status"),
+            r#"public."users"."__reshape_0_0_status""#
+        );
+    }
+
+    #[test]
+    fn rewrites_table_name_to_real_name() {
+        let mut table = table();
+        table.name = "customers".to_string();
+
+        assert_eq!(
+            rewrite_column_references("customers.status", &table).unwrap(),
+            r#""users"."__reshape_0_0_status""#
+        );
+    }
+
+    #[test]
+    fn handles_quoted_and_case_folded_identifiers() {
+        // Unquoted identifiers are lowercased by Postgres, quoted ones are not
+        assert_eq!(rewrite("STATUS"), r#""__reshape_0_0_status""#);
+        assert_eq!(rewrite(r#""status""#), r#""__reshape_0_0_status""#);
+        assert!(rewrite_error(r#""Status""#).contains(r#"column "Status" does not exist"#));
+    }
+
+    #[test]
+    fn rewrites_references_missed_by_pg_query_node_iterator() {
+        assert_eq!(
+            rewrite("ARRAY[status, state]"),
+            r#"ARRAY["__reshape_0_0_status", "old_state"]"#
+        );
+        assert_eq!(rewrite("status[1]"), r#""__reshape_0_0_status"[1]"#);
+        assert_eq!(
+            rewrite(r#"status COLLATE "C""#),
+            r#""__reshape_0_0_status" COLLATE "C""#
+        );
+        assert_eq!(rewrite("(address).city"), r#"("address").city"#);
+    }
+
+    #[test]
+    fn leaves_subqueries_untouched() {
+        assert_eq!(
+            rewrite("status = (SELECT status FROM other WHERE other.id = 1)"),
+            r#""__reshape_0_0_status" = (SELECT status FROM other WHERE other.id = 1)"#
+        );
+        assert_eq!(
+            rewrite("EXISTS (SELECT 1 FROM t WHERE t.missing = 1) AND id > 0"),
+            r#"EXISTS (SELECT 1 FROM t WHERE t.missing = 1) AND "id" > 0"#
+        );
+    }
+
+    #[test]
+    fn treats_composite_field_access_as_column_reference() {
+        assert_eq!(rewrite("address.city"), r#""address".city"#);
+    }
+
+    #[test]
+    fn skips_trigger_rows_and_stars() {
+        assert_eq!(rewrite("NEW.status"), "NEW.status");
+        assert_eq!(rewrite("OLD.status"), "OLD.status");
+        assert_eq!(rewrite("count(*)"), "count(*)");
+    }
+
+    #[test]
+    fn ignores_non_column_identifiers() {
+        assert_eq!(rewrite("now()"), "now()");
+        assert_eq!(rewrite("CURRENT_TIMESTAMP"), "CURRENT_TIMESTAMP");
+        assert_eq!(rewrite("'status'"), "'status'");
+        assert_eq!(rewrite("status::text"), r#""__reshape_0_0_status"::text"#);
+        assert_eq!(
+            rewrite("EXTRACT(year FROM status)"),
+            r#"EXTRACT(year FROM "__reshape_0_0_status")"#
+        );
+    }
+
+    #[test]
+    fn fails_for_unknown_columns() {
+        assert_eq!(
+            rewrite_error("missing"),
+            r#"column "missing" does not exist on table "users""#
+        );
+        assert_eq!(
+            rewrite_error("users.missing"),
+            r#"column "missing" does not exist on table "users""#
+        );
+        assert_eq!(
+            rewrite_error("missing OR also_missing"),
+            r#"column "missing" does not exist on table "users", column "also_missing" does not exist on table "users""#
+        );
+    }
+
+    #[test]
+    fn fails_for_unknown_tables() {
+        assert_eq!(rewrite_error("other.status"), r#"unknown table "other""#);
+    }
+
+    #[test]
+    fn fails_for_invalid_sql() {
+        assert!(rewrite_column_references("INVALID $$$", &table()).is_err());
+    }
+
+    #[test]
+    fn quotes_identifiers_with_quotes() {
+        let mut table = table();
+        table.columns.push(column("weird", r#"we"ird"#));
+
+        assert_eq!(
+            rewrite_column_references("weird", &table).unwrap(),
+            r#""we""ird""#
+        );
+    }
+}

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -643,6 +643,208 @@ fn add_index_with_expression_alongside_a_column_migration() {
     test.run();
 }
 
+#[test]
+fn add_index_referencing_altered_column() {
+    let mut test = Test::new("Add indexes referencing an altered column");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "status"
+            type = "TEXT"
+        "#,
+    );
+
+    // Changing the type replaces `status` with a temporary column. The expression and
+    // predicate reference `status` by name and must be rewritten to the temporary column,
+    // otherwise the indexes are built on the old column and dropped along with it on
+    // completion.
+    test.second_migration(
+        r#"
+        name = "alter_status_and_add_indexes"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "status"
+        up = "status"
+        down = "status"
+
+            [actions.changes]
+            type = "VARCHAR(50)"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_active_idx"
+            columns = ["id"]
+            where = "status = 'active'"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_lower_status_idx"
+            columns = [{ expression = "lower(status)" }]
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        // Both indexes are created against the temporary column
+        for index in ["users_active_idx", "users_lower_status_idx"] {
+            let definition = get_index_definition(db, index);
+            assert!(
+                definition.contains("__reshape"),
+                "expected {} to reference the temporary column, got: {}",
+                index,
+                definition
+            );
+        }
+    });
+
+    test.after_completion(|db| {
+        // Once completed, the indexes follow the column to its final name
+        let definition = get_index_definition(db, "users_active_idx");
+        assert!(
+            definition.contains("WHERE")
+                && definition.contains("status")
+                && !definition.contains("__reshape"),
+            "expected partial index to survive completion, got: {}",
+            definition
+        );
+
+        let definition = get_index_definition(db, "users_lower_status_idx");
+        assert!(
+            definition.contains("lower((status)::text)") || definition.contains("lower(status)"),
+            "expected expression index to survive completion, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_referencing_renamed_column() {
+    let mut test = Test::new("Add index referencing a renamed column");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "status"
+            type = "TEXT"
+        "#,
+    );
+
+    // A rename keeps the real column until completion, so a predicate using the new
+    // name has to be rewritten to the old one for the index to be created
+    test.second_migration(
+        r#"
+        name = "rename_status_and_add_index"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "status"
+
+            [actions.changes]
+            name = "state"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_active_idx"
+            columns = ["id"]
+            where = "state = 'active'"
+        "#,
+    );
+
+    test.intermediate(|db, _| {
+        let definition = get_index_definition(db, "users_active_idx");
+        assert!(
+            definition.contains("(status = 'active'::text)"),
+            "expected predicate to reference the real column, got: {}",
+            definition
+        );
+    });
+
+    test.after_completion(|db| {
+        let definition = get_index_definition(db, "users_active_idx");
+        assert!(
+            definition.contains("(state = 'active'::text)"),
+            "expected predicate to follow the rename, got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_index_referencing_unknown_column() {
+    let mut test = Test::new("Add index referencing an unknown column");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_index_with_bad_predicate"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_active_idx"
+            columns = ["id"]
+            where = "status = 'active'"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
 fn get_index_definition(db: &mut postgres::Client, index_name: &str) -> String {
     db.query(
         "


### PR DESCRIPTION
## Summary

Index expressions and partial index `where` predicates were interpolated into `CREATE INDEX` exactly as written. Plain column entries already map to the real column backing them, but expressions didn't, which caused two failures when an index referenced a column changed earlier in the same migration:

- **Column altered** (temporary column introduced): the index was silently built against the old column and dropped together with it on completion. No error at any point.
- **Column renamed**: index creation failed immediately, since the new name doesn't exist on the real table until completion.

This adds a generic rewriter in `src/sql.rs` and uses it in `add_index` for expressions and predicates.

## How the rewriter works

- Parses the expression with pg_query and walks the serialized parse tree to find every column reference. pg_query's own node iterator skips references inside array constructors, subscripts, field selection and `COLLATE`, so the serialized tree is walked instead. References inside subqueries are skipped since they belong to the subquery's own scope.
- Resolves each reference against the `Table` from the schema tracker, which already carries the current-name to real-name mapping for both table and columns. Qualified references (`users.status`, `public.users.status`) rewrite the table name too. `NEW`/`OLD` and composite field access are handled.
- Splices the quoted real names back into the original text using the parser's byte offsets and scanner token spans, so the user's formatting is preserved and nothing is deparsed.
- Unknown columns or tables fail the migration with e.g. `column "foo" does not exist on table "users"`, collected across the whole expression.

The existing `validate_sql_expression` / `validate_sql_statement` helpers move into the new module and are re-exported from `migrations`.

## Test plan

- [x] 14 unit tests on the rewriter: real name mapping, qualified and three-part references, table rename, quoted and case-folded identifiers, formatting preservation, the node types pg_query's iterator misses, subqueries, composite access, `NEW`/`OLD`, stars, unknown columns/tables, invalid SQL, identifier quoting
- [x] `add_index_referencing_altered_column`: expression and partial index on a column altered in the same migration are built on the temporary column and survive completion (previously silently dropped)
- [x] `add_index_referencing_renamed_column`: predicate using the new name works and follows the rename on completion (previously failed)
- [x] `add_index_referencing_unknown_column`: fails the migration
- [x] Full suite passes, `cargo clippy -- -D warnings` clean

## Follow-ups (separate PRs)

- Use the same resolver to validate column references in `up`/`down`/`value`/`where` trigger expressions across the other actions
- Fix `alter_column` index duplication, which currently loses pre-existing partial and expression indexes on the altered column at completion