### PR TITLE
Validate column references in migration SQL expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,8 +446,8 @@ table = "profiles"
 	# When `users` is updated in the old schema, we write the email value to `profiles`
 	[actions.up]
 	table = "users"
-	value = "email"
-	where = "user_id = id"
+	value = "users.email"
+	where = "profiles.user_id = users.id"
 ```
 
 #### Alter column

--- a/src/docs/actions/add-column.md
+++ b/src/docs/actions/add-column.md
@@ -138,3 +138,5 @@ table = "products"
 - For non-nullable columns, provide either `default` or `up` to populate existing rows
 - The `up` expression is evaluated for each row during backfill
 - Cross-table `up` requires a previous migration schema to exist
+- In a cross-table `up`, every column in `value` and `where` must be qualified with its
+  table name, as the expressions run in triggers on both tables

--- a/src/docs/actions/remove-column.md
+++ b/src/docs/actions/remove-column.md
@@ -90,4 +90,6 @@ column = "customer_name"
 - The column is only removed during the complete phase
 - If the column is NOT NULL and you need backward compatibility, provide a `down` expression
 - For non-nullable columns with complex `down`, the NOT NULL constraint is temporarily converted to a trigger
+- In a cross-table `down`, every column in `value` and `where` must be qualified with its
+  table name, as the expressions run in triggers on both tables
 - Data in the column is permanently lost after completion

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    migrations::{quote_string_literal, validate_sql, Migration, MigrationContext},
+    migrations::{quote_string_literal, validate_sql_against_schema, Migration, MigrationContext},
     schema::Schema,
 };
 
@@ -278,7 +278,14 @@ fn migrate(
             print!("  + {} ", description);
 
             // Validate SQL before running action
-            let validation_errors = validate_sql(action.as_ref());
+            let validation_errors =
+                match validate_sql_against_schema(action.as_ref(), db, &new_schema) {
+                    Ok(errors) => errors,
+                    Err(err) => {
+                        result = Err(err);
+                        break 'outer;
+                    }
+                };
             if !validation_errors.is_empty() {
                 for error in &validation_errors {
                     println!(

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -465,8 +465,10 @@ impl Action for AddColumn {
                 value,
                 r#where,
             }) => {
-                let tables =
-                    References::Tables(TableScope::schema(table), TableScope::schema(&self.table));
+                let tables = References::CrossTable(
+                    TableScope::schema(table),
+                    TableScope::schema(&self.table),
+                );
                 fields.push(SqlField::expression("up.value", value, tables.clone()));
                 fields.push(SqlField::expression("up.where", r#where, tables));
             }

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -465,8 +465,10 @@ impl Action for AddColumn {
                 value,
                 r#where,
             }) => {
-                let tables =
-                    References::Tables(vec![TableScope::new(table), TableScope::new(&self.table)]);
+                let tables = References::Tables(vec![
+                    TableScope::schema(table),
+                    TableScope::schema(&self.table),
+                ]);
                 fields.push(SqlField::expression("up.value", value, tables.clone()));
                 fields.push(SqlField::expression("up.where", r#where, tables));
             }

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -1,4 +1,7 @@
-use super::{common, quote_string_literal, Action, Column, MigrationContext, SqlField};
+use super::{
+    common, quote_string_literal, Action, Column, MigrationContext, References, SqlField,
+    TableScope,
+};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -447,18 +450,36 @@ impl Action for AddColumn {
         let mut fields = vec![];
 
         match &self.up {
+            // `up` runs in a trigger on the table and can reference its existing columns
             Some(Transformation::Simple(up)) => {
-                fields.push(SqlField::expression("up", up));
+                fields.push(SqlField::expression(
+                    "up",
+                    up,
+                    References::table(&self.table),
+                ));
             }
-            Some(Transformation::Update { value, r#where, .. }) => {
-                fields.push(SqlField::expression("up.value", value));
-                fields.push(SqlField::expression("up.where", r#where));
+            // A cross-table `up` can reference both the table the values are taken from
+            // and the table being changed
+            Some(Transformation::Update {
+                table,
+                value,
+                r#where,
+            }) => {
+                let tables = || {
+                    References::Tables(vec![TableScope::new(table), TableScope::new(&self.table)])
+                };
+                fields.push(SqlField::expression("up.value", value, tables()));
+                fields.push(SqlField::expression("up.where", r#where, tables()));
             }
             None => {}
         }
 
         if let Some(default) = &self.column.default {
-            fields.push(SqlField::expression("column.default", default));
+            fields.push(SqlField::expression(
+                "column.default",
+                default,
+                References::Forbidden,
+            ));
         }
 
         fields

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -465,11 +465,10 @@ impl Action for AddColumn {
                 value,
                 r#where,
             }) => {
-                let tables = || {
-                    References::Tables(vec![TableScope::new(table), TableScope::new(&self.table)])
-                };
-                fields.push(SqlField::expression("up.value", value, tables()));
-                fields.push(SqlField::expression("up.where", r#where, tables()));
+                let tables =
+                    References::Tables(vec![TableScope::new(table), TableScope::new(&self.table)]);
+                fields.push(SqlField::expression("up.value", value, tables.clone()));
+                fields.push(SqlField::expression("up.where", r#where, tables));
             }
             None => {}
         }

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -465,10 +465,8 @@ impl Action for AddColumn {
                 value,
                 r#where,
             }) => {
-                let tables = References::Tables(vec![
-                    TableScope::schema(table),
-                    TableScope::schema(&self.table),
-                ]);
+                let tables =
+                    References::Tables(TableScope::schema(table), TableScope::schema(&self.table));
                 fields.push(SqlField::expression("up.value", value, tables.clone()));
                 fields.push(SqlField::expression("up.where", r#where, tables));
             }

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -1,4 +1,4 @@
-use super::{Action, MigrationContext, SqlField};
+use super::{Action, MigrationContext, References, SqlField};
 use crate::{
     db::{Conn, Transaction},
     schema::{Schema, Table},
@@ -210,13 +210,18 @@ impl Action for AddIndex {
                 IndexColumn::Expression(spec) => Some(SqlField::expression(
                     format!("index.columns[{}].expression", idx),
                     &spec.expression,
+                    References::table(&self.table),
                 )),
                 _ => None,
             })
             .collect();
 
         if let Some(predicate) = &self.index.r#where {
-            fields.push(SqlField::expression("index.where", predicate));
+            fields.push(SqlField::expression(
+                "index.where",
+                predicate,
+                References::table(&self.table),
+            ));
         }
 
         fields

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -1,4 +1,4 @@
-use super::{Action, MigrationContext, SqlField};
+use super::{Action, MigrationContext, References, SqlField};
 use crate::{
     db::{Conn, Transaction},
     migrations::common,
@@ -59,11 +59,7 @@ impl Action for AlterColumn {
             vec![&temporary_column_name, temporary_column_type];
 
         // Use either new default value or existing one if one exists
-        let default_value = self
-            .changes
-            .default
-            .as_ref()
-            .or(column.default.as_ref());
+        let default_value = self.changes.default.as_ref().or(column.default.as_ref());
         if let Some(default) = default_value {
             temp_column_definition_parts.push("DEFAULT");
             temp_column_definition_parts.push(default);
@@ -437,17 +433,29 @@ impl Action for AlterColumn {
     }
 
     fn sql_fields(&self) -> Vec<SqlField> {
-        [
-            ("up", &self.up),
-            ("down", &self.down),
-            ("changes.default", &self.changes.default),
-        ]
-        .into_iter()
-        .filter_map(|(field, sql)| {
-            sql.as_ref()
-                .map(|sql| SqlField::expression(field, sql))
-        })
-        .collect()
+        let mut fields = vec![];
+
+        // Both `up` and `down` run in triggers on the table. The column being altered is
+        // available under its current name in both, even when it's being renamed.
+        for (name, sql) in [("up", &self.up), ("down", &self.down)] {
+            if let Some(sql) = sql {
+                fields.push(SqlField::expression(
+                    name,
+                    sql,
+                    References::table(&self.table),
+                ));
+            }
+        }
+
+        if let Some(default) = &self.changes.default {
+            fields.push(SqlField::expression(
+                "changes.default",
+                default,
+                References::Forbidden,
+            ));
+        }
+
+        fields
     }
 }
 

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::{
     common::{Check, ForeignKey},
-    quote_string_literal, Action, Column, MigrationContext, References, SqlField,
+    quote_string_literal, Action, Column, MigrationContext, References, SqlField, TableScope,
 };
 use crate::{
     db::{Conn, Transaction},
@@ -311,7 +311,7 @@ impl Action for CreateTable {
             fields.push(SqlField::expression(
                 format!("checks[{}].expression", idx),
                 &check.expression,
-                References::Table(self.schema_table()),
+                References::Tables(vec![TableScope::Explicit(self.schema_table())]),
             ));
         }
 

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 
 use super::{
     common::{Check, ForeignKey},
-    quote_string_literal, Action, Column, MigrationContext, SqlField,
+    quote_string_literal, Action, Column, MigrationContext, References, SqlField,
 };
 use crate::{
     db::{Conn, Transaction},
     migrations::common,
-    schema::Schema,
+    schema::{self, Schema, Table},
 };
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -39,6 +39,25 @@ pub struct Transformation {
 impl CreateTable {
     fn trigger_name(&self, ctx: &MigrationContext) -> String {
         format!("{}_create_table_{}", ctx.prefix(), self.name)
+    }
+
+    // The table as it will look once created
+    fn schema_table(&self) -> Table {
+        Table {
+            name: self.name.clone(),
+            real_name: self.name.clone(),
+            columns: self
+                .columns
+                .iter()
+                .map(|column| schema::Column {
+                    name: column.name.clone(),
+                    real_name: column.name.clone(),
+                    data_type: column.data_type.clone(),
+                    nullable: column.nullable,
+                    default: column.default.clone(),
+                })
+                .collect(),
+        }
     }
 }
 
@@ -282,22 +301,27 @@ impl Action for CreateTable {
                 fields.push(SqlField::expression(
                     format!("columns[{}].default", idx),
                     default,
+                    References::Forbidden,
                 ));
             }
         }
 
+        // Checks can only reference the table's own columns
         for (idx, check) in self.checks.iter().enumerate() {
             fields.push(SqlField::expression(
                 format!("checks[{}].expression", idx),
                 &check.expression,
+                References::Table(self.schema_table()),
             ));
         }
 
-        if let Some(Transformation { values, .. }) = &self.up {
+        // Values are computed from rows of the table the data is copied from
+        if let Some(Transformation { table, values, .. }) = &self.up {
             for (column, value) in values {
                 fields.push(SqlField::expression(
                     format!("up.values.{}", column),
                     value,
+                    References::table(table),
                 ));
             }
         }

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -311,7 +311,7 @@ impl Action for CreateTable {
             fields.push(SqlField::expression(
                 format!("checks[{}].expression", idx),
                 &check.expression,
-                References::Tables(vec![TableScope::Explicit(self.schema_table())]),
+                References::Table(TableScope::Explicit(self.schema_table())),
             ));
         }
 

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{Conn, Transaction},
-    schema::Schema,
+    schema::{Schema, Table},
 };
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
@@ -11,6 +11,49 @@ pub struct SqlField {
     pub name: String,
     pub sql: String,
     pub kind: SqlKind,
+    pub references: References,
+}
+
+/// The columns a piece of SQL may reference
+#[derive(Debug, Clone)]
+pub enum References {
+    /// Not checked
+    Unchecked,
+    /// The SQL may not reference any columns at all
+    Forbidden,
+    /// Columns of a table which doesn't exist in the schema yet
+    Table(Table),
+    /// Columns of tables in the schema, checked right before the action runs
+    Tables(Vec<TableScope>),
+}
+
+impl References {
+    pub fn table(table: &str) -> Self {
+        References::Tables(vec![TableScope::new(table)])
+    }
+}
+
+/// A table whose columns may be referenced
+#[derive(Debug, Clone)]
+pub struct TableScope {
+    pub table: String,
+    /// Columns which exist on the table but can't be referenced, such as a column which is
+    /// being removed
+    pub excluded_columns: Vec<String>,
+}
+
+impl TableScope {
+    pub fn new(table: &str) -> Self {
+        TableScope {
+            table: table.to_string(),
+            excluded_columns: Vec::new(),
+        }
+    }
+
+    pub fn excluding(mut self, column: &str) -> Self {
+        self.excluded_columns.push(column.to_string());
+        self
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,11 +65,16 @@ pub enum SqlKind {
 }
 
 impl SqlField {
-    pub fn expression(name: impl Into<String>, sql: impl Into<String>) -> Self {
+    pub fn expression(
+        name: impl Into<String>,
+        sql: impl Into<String>,
+        references: References,
+    ) -> Self {
         SqlField {
             name: name.into(),
             sql: sql.into(),
             kind: SqlKind::Expression,
+            references,
         }
     }
 
@@ -35,6 +83,7 @@ impl SqlField {
             name: name.into(),
             sql: sql.into(),
             kind: SqlKind::Statement,
+            references: References::Unchecked,
         }
     }
 }
@@ -47,23 +96,99 @@ pub struct SqlError {
     pub message: String,
 }
 
+/// Validates the SQL of an action as far as possible without a schema: the syntax of every
+/// field and the column references which don't depend on existing tables
 pub fn validate_sql(action: &dyn Action) -> Vec<SqlError> {
     action
         .sql_fields()
         .into_iter()
         .filter_map(|field| {
-            let result = match field.kind {
-                SqlKind::Expression => crate::sql::validate_sql_expression(&field.sql),
-                SqlKind::Statement => crate::sql::validate_sql_statement(&field.sql),
-            };
-
-            result.err().map(|message| SqlError {
+            validate_field(&field).err().map(|message| SqlError {
                 field: field.name,
                 sql: field.sql,
                 message,
             })
         })
         .collect()
+}
+
+/// Validates the SQL of an action, including column references against the tables of
+/// the schema as it looks right before the action runs
+pub fn validate_sql_against_schema(
+    action: &dyn Action,
+    db: &mut dyn Conn,
+    schema: &Schema,
+) -> anyhow::Result<Vec<SqlError>> {
+    let mut errors = Vec::new();
+
+    for field in action.sql_fields() {
+        let result = match (validate_field(&field), &field.references) {
+            (Ok(()), References::Tables(scopes)) => {
+                validate_references_against_schema(&field.sql, scopes, db, schema)?
+            }
+            (result, _) => result,
+        };
+
+        if let Err(message) = result {
+            errors.push(SqlError {
+                field: field.name,
+                sql: field.sql,
+                message,
+            });
+        }
+    }
+
+    Ok(errors)
+}
+
+fn validate_field(field: &SqlField) -> Result<(), String> {
+    match field.kind {
+        SqlKind::Expression => crate::sql::validate_sql_expression(&field.sql)?,
+        SqlKind::Statement => crate::sql::validate_sql_statement(&field.sql)?,
+    }
+
+    match &field.references {
+        References::Forbidden => crate::sql::validate_no_column_references(&field.sql),
+        References::Table(table) => {
+            join_errors(crate::sql::validate_column_references(&field.sql, &[table]))
+        }
+        References::Unchecked | References::Tables(_) => Ok(()),
+    }
+}
+
+fn validate_references_against_schema(
+    sql: &str,
+    scopes: &[TableScope],
+    db: &mut dyn Conn,
+    schema: &Schema,
+) -> anyhow::Result<Result<(), String>> {
+    let mut tables = Vec::new();
+    for scope in scopes {
+        let mut table = schema.get_table(db, &scope.table)?;
+
+        // A table which doesn't exist comes back without any columns
+        if table.columns.is_empty() {
+            return Ok(Err(format!("table \"{}\" does not exist", scope.table)));
+        }
+
+        table
+            .columns
+            .retain(|column| !scope.excluded_columns.contains(&column.name));
+        tables.push(table);
+    }
+
+    let tables: Vec<&Table> = tables.iter().collect();
+    Ok(join_errors(crate::sql::validate_column_references(
+        sql, &tables,
+    )))
+}
+
+fn join_errors(errors: Vec<String>) -> Result<(), String> {
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join(", "))
+    }
 }
 
 /// Quote a value so it can be used as an SQL string literal.

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -21,13 +21,25 @@ pub enum References {
     Unchecked,
     /// The SQL may not reference any columns at all
     Forbidden,
-    /// Columns of the given tables
-    Tables(Vec<TableScope>),
+    /// Columns of a table, referenced with or without the table name
+    Table(TableScope),
+    /// Columns of two tables, as in a cross-table transformation. Every reference must
+    /// be qualified with the name of its table, as the SQL runs in triggers on both
+    /// tables where an unqualified name would resolve differently.
+    Tables(TableScope, TableScope),
 }
 
 impl References {
     pub fn table(table: &str) -> Self {
-        References::Tables(vec![TableScope::schema(table)])
+        References::Table(TableScope::schema(table))
+    }
+
+    fn scopes(&self) -> Vec<&TableScope> {
+        match self {
+            References::Unchecked | References::Forbidden => vec![],
+            References::Table(scope) => vec![scope],
+            References::Tables(first, second) => vec![first, second],
+        }
     }
 }
 
@@ -134,11 +146,12 @@ pub fn validate_sql_against_schema(
     let mut errors = Vec::new();
 
     for field in action.sql_fields() {
-        let result = match (validate_field(&field), &field.references) {
-            (Ok(()), References::Tables(scopes)) if !scopes.iter().all(TableScope::is_explicit) => {
-                validate_references_against_schema(&field.sql, scopes, db, schema)?
+        let scopes = field.references.scopes();
+        let result = match validate_field(&field) {
+            Ok(()) if !scopes.iter().all(|scope| scope.is_explicit()) => {
+                validate_references_against_schema(&field.sql, &scopes, db, schema)?
             }
-            (result, _) => result,
+            result => result,
         };
 
         if let Err(message) = result {
@@ -159,26 +172,29 @@ fn validate_field(field: &SqlField) -> Result<(), String> {
         SqlKind::Statement => crate::sql::validate_sql_statement(&field.sql)?,
     }
 
-    match &field.references {
-        References::Forbidden => crate::sql::validate_no_column_references(&field.sql),
-        // Tables in the schema can only be checked once the schema is available
-        References::Tables(scopes) if scopes.iter().all(TableScope::is_explicit) => {
-            let tables: Vec<&Table> = scopes
-                .iter()
-                .filter_map(|scope| match scope {
-                    TableScope::Explicit(table) => Some(table),
-                    TableScope::Schema { .. } => None,
-                })
-                .collect();
-            join_errors(crate::sql::validate_column_references(&field.sql, &tables))
-        }
-        References::Unchecked | References::Tables(_) => Ok(()),
+    if let References::Forbidden = field.references {
+        return crate::sql::validate_no_column_references(&field.sql);
     }
+
+    // Tables in the schema can only be checked once the schema is available
+    let scopes = field.references.scopes();
+    if scopes.is_empty() || !scopes.iter().all(|scope| scope.is_explicit()) {
+        return Ok(());
+    }
+
+    let tables: Vec<&Table> = scopes
+        .iter()
+        .filter_map(|scope| match scope {
+            TableScope::Explicit(table) => Some(table),
+            TableScope::Schema { .. } => None,
+        })
+        .collect();
+    join_errors(crate::sql::validate_column_references(&field.sql, &tables))
 }
 
 fn validate_references_against_schema(
     sql: &str,
-    scopes: &[TableScope],
+    scopes: &[&TableScope],
     db: &mut dyn Conn,
     schema: &Schema,
 ) -> anyhow::Result<Result<(), String>> {

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -21,38 +21,50 @@ pub enum References {
     Unchecked,
     /// The SQL may not reference any columns at all
     Forbidden,
-    /// Columns of a table which doesn't exist in the schema yet
-    Table(Table),
-    /// Columns of tables in the schema, checked right before the action runs
+    /// Columns of the given tables
     Tables(Vec<TableScope>),
 }
 
 impl References {
     pub fn table(table: &str) -> Self {
-        References::Tables(vec![TableScope::new(table)])
+        References::Tables(vec![TableScope::schema(table)])
     }
 }
 
 /// A table whose columns may be referenced
 #[derive(Debug, Clone)]
-pub struct TableScope {
-    pub table: String,
-    /// Columns which exist on the table but can't be referenced, such as a column which is
-    /// being removed
-    pub excluded_columns: Vec<String>,
+pub enum TableScope {
+    /// A table in the schema, resolved right before the action runs
+    Schema {
+        table: String,
+        /// Columns which exist on the table but can't be referenced, such as a column
+        /// which is being removed
+        excluded_columns: Vec<String>,
+    },
+    /// A table which doesn't exist in the schema yet, with its columns known up front
+    Explicit(Table),
 }
 
 impl TableScope {
-    pub fn new(table: &str) -> Self {
-        TableScope {
+    pub fn schema(table: &str) -> Self {
+        TableScope::Schema {
             table: table.to_string(),
             excluded_columns: Vec::new(),
         }
     }
 
     pub fn excluding(mut self, column: &str) -> Self {
-        self.excluded_columns.push(column.to_string());
+        match &mut self {
+            TableScope::Schema {
+                excluded_columns, ..
+            } => excluded_columns.push(column.to_string()),
+            TableScope::Explicit(table) => table.columns.retain(|c| c.name != column),
+        }
         self
+    }
+
+    fn is_explicit(&self) -> bool {
+        matches!(self, TableScope::Explicit(_))
     }
 }
 
@@ -123,7 +135,7 @@ pub fn validate_sql_against_schema(
 
     for field in action.sql_fields() {
         let result = match (validate_field(&field), &field.references) {
-            (Ok(()), References::Tables(scopes)) => {
+            (Ok(()), References::Tables(scopes)) if !scopes.iter().all(TableScope::is_explicit) => {
                 validate_references_against_schema(&field.sql, scopes, db, schema)?
             }
             (result, _) => result,
@@ -149,8 +161,16 @@ fn validate_field(field: &SqlField) -> Result<(), String> {
 
     match &field.references {
         References::Forbidden => crate::sql::validate_no_column_references(&field.sql),
-        References::Table(table) => {
-            join_errors(crate::sql::validate_column_references(&field.sql, &[table]))
+        // Tables in the schema can only be checked once the schema is available
+        References::Tables(scopes) if scopes.iter().all(TableScope::is_explicit) => {
+            let tables: Vec<&Table> = scopes
+                .iter()
+                .filter_map(|scope| match scope {
+                    TableScope::Explicit(table) => Some(table),
+                    TableScope::Schema { .. } => None,
+                })
+                .collect();
+            join_errors(crate::sql::validate_column_references(&field.sql, &tables))
         }
         References::Unchecked | References::Tables(_) => Ok(()),
     }
@@ -164,16 +184,25 @@ fn validate_references_against_schema(
 ) -> anyhow::Result<Result<(), String>> {
     let mut tables = Vec::new();
     for scope in scopes {
-        let mut table = schema.get_table(db, &scope.table)?;
+        let table = match scope {
+            TableScope::Explicit(table) => table.clone(),
+            TableScope::Schema {
+                table,
+                excluded_columns,
+            } => {
+                let mut resolved = schema.get_table(db, table)?;
 
-        // A table which doesn't exist comes back without any columns
-        if table.columns.is_empty() {
-            return Ok(Err(format!("table \"{}\" does not exist", scope.table)));
-        }
+                // A table which doesn't exist comes back without any columns
+                if resolved.columns.is_empty() {
+                    return Ok(Err(format!("table \"{}\" does not exist", table)));
+                }
 
-        table
-            .columns
-            .retain(|column| !scope.excluded_columns.contains(&column.name));
+                resolved
+                    .columns
+                    .retain(|column| !excluded_columns.contains(&column.name));
+                resolved
+            }
+        };
         tables.push(table);
     }
 

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -23,10 +23,10 @@ pub enum References {
     Forbidden,
     /// Columns of a table, referenced with or without the table name
     Table(TableScope),
-    /// Columns of two tables, as in a cross-table transformation. Every reference must
+    /// Columns of the two tables of a cross-table transformation. Every reference must
     /// be qualified with the name of its table, as the SQL runs in triggers on both
     /// tables where an unqualified name would resolve differently.
-    Tables(TableScope, TableScope),
+    CrossTable(TableScope, TableScope),
 }
 
 impl References {
@@ -38,7 +38,7 @@ impl References {
         match self {
             References::Unchecked | References::Forbidden => vec![],
             References::Table(scope) => vec![scope],
-            References::Tables(first, second) => vec![first, second],
+            References::CrossTable(first, second) => vec![first, second],
         }
     }
 }

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -470,7 +470,7 @@ impl Action for RemoveColumn {
                 SqlField::expression(
                     "down.value",
                     value,
-                    References::Tables(
+                    References::CrossTable(
                         TableScope::schema(table),
                         TableScope::schema(&self.table).excluding(&self.column),
                     ),
@@ -478,7 +478,10 @@ impl Action for RemoveColumn {
                 SqlField::expression(
                     "down.where",
                     r#where,
-                    References::Tables(TableScope::schema(table), TableScope::schema(&self.table)),
+                    References::CrossTable(
+                        TableScope::schema(table),
+                        TableScope::schema(&self.table),
+                    ),
                 ),
             ],
             None => vec![],

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -458,7 +458,7 @@ impl Action for RemoveColumn {
             Some(Transformation::Simple(down)) => vec![SqlField::expression(
                 "down",
                 down,
-                References::Tables(vec![TableScope::new(&self.table).excluding(&self.column)]),
+                References::Tables(vec![TableScope::schema(&self.table).excluding(&self.column)]),
             )],
             // A cross-table `down` takes values from another table. The `where` clause
             // matches rows of the changed table and may use any of its columns.
@@ -471,14 +471,17 @@ impl Action for RemoveColumn {
                     "down.value",
                     value,
                     References::Tables(vec![
-                        TableScope::new(table),
-                        TableScope::new(&self.table).excluding(&self.column),
+                        TableScope::schema(table),
+                        TableScope::schema(&self.table).excluding(&self.column),
                     ]),
                 ),
                 SqlField::expression(
                     "down.where",
                     r#where,
-                    References::Tables(vec![TableScope::new(table), TableScope::new(&self.table)]),
+                    References::Tables(vec![
+                        TableScope::schema(table),
+                        TableScope::schema(&self.table),
+                    ]),
                 ),
             ],
             None => vec![],

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -458,7 +458,7 @@ impl Action for RemoveColumn {
             Some(Transformation::Simple(down)) => vec![SqlField::expression(
                 "down",
                 down,
-                References::Tables(vec![TableScope::schema(&self.table).excluding(&self.column)]),
+                References::Table(TableScope::schema(&self.table).excluding(&self.column)),
             )],
             // A cross-table `down` takes values from another table. The `where` clause
             // matches rows of the changed table and may use any of its columns.
@@ -470,18 +470,15 @@ impl Action for RemoveColumn {
                 SqlField::expression(
                     "down.value",
                     value,
-                    References::Tables(vec![
+                    References::Tables(
                         TableScope::schema(table),
                         TableScope::schema(&self.table).excluding(&self.column),
-                    ]),
+                    ),
                 ),
                 SqlField::expression(
                     "down.where",
                     r#where,
-                    References::Tables(vec![
-                        TableScope::schema(table),
-                        TableScope::schema(&self.table),
-                    ]),
+                    References::Tables(TableScope::schema(table), TableScope::schema(&self.table)),
                 ),
             ],
             None => vec![],

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -1,4 +1,4 @@
-use super::{common, Action, MigrationContext, SqlField};
+use super::{common, Action, MigrationContext, References, SqlField, TableScope};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -454,10 +454,32 @@ impl Action for RemoveColumn {
 
     fn sql_fields(&self) -> Vec<SqlField> {
         match &self.down {
-            Some(Transformation::Simple(down)) => vec![SqlField::expression("down", down)],
-            Some(Transformation::Update { value, r#where, .. }) => vec![
-                SqlField::expression("down.value", value),
-                SqlField::expression("down.where", r#where),
+            // `down` computes the value of the removed column and can't reference it
+            Some(Transformation::Simple(down)) => vec![SqlField::expression(
+                "down",
+                down,
+                References::Tables(vec![TableScope::new(&self.table).excluding(&self.column)]),
+            )],
+            // A cross-table `down` takes values from another table. The `where` clause
+            // matches rows of the changed table and may use any of its columns.
+            Some(Transformation::Update {
+                table,
+                value,
+                r#where,
+            }) => vec![
+                SqlField::expression(
+                    "down.value",
+                    value,
+                    References::Tables(vec![
+                        TableScope::new(table),
+                        TableScope::new(&self.table).excluding(&self.column),
+                    ]),
+                ),
+                SqlField::expression(
+                    "down.where",
+                    r#where,
+                    References::Tables(vec![TableScope::new(table), TableScope::new(&self.table)]),
+                ),
             ],
             None => vec![],
         }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -138,14 +138,14 @@ impl ColumnChanges {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Table {
     pub name: String,
     pub real_name: String,
     pub columns: Vec<Column>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Column {
     pub name: String,
     pub real_name: String,

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -174,8 +174,17 @@ fn resolve<'a>(
     let fields = &reference.fields;
 
     match fields.len() {
-        // Unqualified column, e.g. `name`
+        // Unqualified column, e.g. `name`. With more than one table in scope, the name
+        // could resolve to a different table depending on where the SQL runs, so it
+        // must be qualified.
         1 => {
+            if tables.len() > 1 {
+                return Err(format!(
+                    "column \"{}\" must be qualified with a table name",
+                    fields[0]
+                ));
+            }
+
             let (table, column) = find_column(tables, &fields[0])?;
             Ok(Some(Resolution {
                 table_field: None,
@@ -206,7 +215,7 @@ fn resolve<'a>(
 
             // A two-part reference can also be a field of a composite-typed column, e.g.
             // `address.city`. In that case, the first part is the column reference.
-            if fields.len() == 2 {
+            if fields.len() == 2 && tables.len() == 1 {
                 if let Ok((table, column)) = find_column(tables, qualifier) {
                     return Ok(Some(Resolution {
                         table_field: None,
@@ -481,21 +490,26 @@ mod tests {
         let profiles = other_table();
         let tables = [&users, &profiles];
 
-        // Unqualified columns may come from either table, qualified ones must match
-        assert!(validate_column_references("user_id = id", &tables).is_empty());
+        // Every reference must be qualified when more than one table is in scope
         assert!(validate_column_references("profiles.user_id = users.id", &tables).is_empty());
-        assert!(validate_column_references("lower(email) = status", &tables).is_empty());
+        assert!(
+            validate_column_references("lower(profiles.email) = users.status", &tables).is_empty()
+        );
 
         assert_eq!(
-            validate_column_references("missing = id", &tables),
-            vec![r#"column "missing" does not exist on tables "users" or "profiles""#]
+            validate_column_references("user_id = users.id", &tables),
+            vec![r#"column "user_id" must be qualified with a table name"#]
         );
         assert_eq!(
-            validate_column_references("users.email = id", &tables),
+            validate_column_references("profiles.missing = users.id", &tables),
+            vec![r#"column "missing" does not exist on table "profiles""#]
+        );
+        assert_eq!(
+            validate_column_references("users.email = users.id", &tables),
             vec![r#"column "email" does not exist on table "users""#]
         );
         assert_eq!(
-            validate_column_references("accounts.id = id", &tables),
+            validate_column_references("accounts.id = users.id", &tables),
             vec![r#"unknown table "accounts""#]
         );
     }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -32,7 +32,7 @@ pub fn rewrite_column_references(expression: &str, table: &Table) -> anyhow::Res
     let mut errors = Vec::new();
     let mut resolutions = Vec::new();
     for reference in references {
-        match resolve(&reference, table) {
+        match resolve(&reference, &[table]) {
             Ok(Some(resolution)) => resolutions.push((reference, resolution)),
             Ok(None) => {}
             Err(error) => errors.push(error),
@@ -45,6 +45,35 @@ pub fn rewrite_column_references(expression: &str, table: &Table) -> anyhow::Res
 
     let rewritten = splice(&wrapped, &resolutions).map_err(|e| anyhow!(e))?;
     Ok(unwrap_expression(&rewritten))
+}
+
+/// Checks that every column referenced by an expression exists in one of the given tables.
+/// Unqualified columns may belong to any of the tables, qualified ones must match the
+/// table they name. Returns one error message per invalid reference.
+pub fn validate_column_references(expression: &str, tables: &[&Table]) -> Vec<String> {
+    let references = match extract_column_references(&wrap_expression(expression)) {
+        Ok(references) => references,
+        Err(error) => return vec![error],
+    };
+
+    references
+        .iter()
+        .filter_map(|reference| resolve(reference, tables).err())
+        .collect()
+}
+
+/// Checks that an expression doesn't reference any columns at all, which is the case for
+/// default values.
+pub fn validate_no_column_references(expression: &str) -> Result<(), String> {
+    let references = extract_column_references(&wrap_expression(expression))?;
+
+    match references.first() {
+        Some(reference) => Err(format!(
+            "column references are not allowed here, found \"{}\"",
+            reference.fields.join(".")
+        )),
+        None => Ok(()),
+    }
 }
 
 const EXPRESSION_PREFIX: &str = "SELECT (";
@@ -136,18 +165,18 @@ struct Resolution<'a> {
     column: &'a Column,
 }
 
-/// Resolves a reference against a table. Returns `Ok(None)` for references which can't
-/// be checked, such as the `NEW` and `OLD` rows available in triggers.
+/// Resolves a reference against a set of tables. Returns `Ok(None)` for references which
+/// can't be checked, such as the `NEW` and `OLD` rows available in triggers.
 fn resolve<'a>(
     reference: &ColumnReference,
-    table: &'a Table,
+    tables: &[&'a Table],
 ) -> Result<Option<Resolution<'a>>, String> {
     let fields = &reference.fields;
 
     match fields.len() {
         // Unqualified column, e.g. `name`
         1 => {
-            let column = find_column(table, &fields[0])?;
+            let (table, column) = find_column(tables, &fields[0])?;
             Ok(Some(Resolution {
                 table_field: None,
                 table,
@@ -161,8 +190,8 @@ fn resolve<'a>(
             let column_field = fields.len() - 1;
             let qualifier = &fields[qualifier_field];
 
-            if *qualifier == table.name {
-                let column = find_column(table, &fields[column_field])?;
+            if let Some(table) = tables.iter().find(|table| table.name == *qualifier) {
+                let (table, column) = find_column(&[table], &fields[column_field])?;
                 return Ok(Some(Resolution {
                     table_field: Some(qualifier_field),
                     table,
@@ -178,7 +207,7 @@ fn resolve<'a>(
             // A two-part reference can also be a field of a composite-typed column, e.g.
             // `address.city`. In that case, the first part is the column reference.
             if fields.len() == 2 {
-                if let Some(column) = table.get_column(qualifier) {
+                if let Ok((table, column)) = find_column(tables, qualifier) {
                     return Ok(Some(Resolution {
                         table_field: None,
                         table,
@@ -194,13 +223,23 @@ fn resolve<'a>(
     }
 }
 
-fn find_column<'a>(table: &'a Table, name: &str) -> Result<&'a Column, String> {
-    table.get_column(name).ok_or_else(|| {
-        format!(
-            "column \"{}\" does not exist on table \"{}\"",
-            name, table.name
-        )
-    })
+fn find_column<'a>(tables: &[&'a Table], name: &str) -> Result<(&'a Table, &'a Column), String> {
+    tables
+        .iter()
+        .find_map(|table| table.get_column(name).map(|column| (*table, column)))
+        .ok_or_else(|| {
+            let table_names: Vec<String> = tables
+                .iter()
+                .map(|table| format!("\"{}\"", table.name))
+                .collect();
+            let noun = if tables.len() == 1 { "table" } else { "tables" };
+            format!(
+                "column \"{}\" does not exist on {} {}",
+                name,
+                noun,
+                table_names.join(" or ")
+            )
+        })
 }
 
 /// Replaces the resolved table and column names in the SQL with their real names, leaving
@@ -426,6 +465,68 @@ mod tests {
     #[test]
     fn fails_for_invalid_sql() {
         assert!(rewrite_column_references("INVALID $$$", &table()).is_err());
+    }
+
+    fn other_table() -> Table {
+        Table {
+            name: "profiles".to_string(),
+            real_name: "profiles".to_string(),
+            columns: vec![column("user_id", "user_id"), column("email", "email")],
+        }
+    }
+
+    #[test]
+    fn validates_references_against_multiple_tables() {
+        let users = table();
+        let profiles = other_table();
+        let tables = [&users, &profiles];
+
+        // Unqualified columns may come from either table, qualified ones must match
+        assert!(validate_column_references("user_id = id", &tables).is_empty());
+        assert!(validate_column_references("profiles.user_id = users.id", &tables).is_empty());
+        assert!(validate_column_references("lower(email) = status", &tables).is_empty());
+
+        assert_eq!(
+            validate_column_references("missing = id", &tables),
+            vec![r#"column "missing" does not exist on tables "users" or "profiles""#]
+        );
+        assert_eq!(
+            validate_column_references("users.email = id", &tables),
+            vec![r#"column "email" does not exist on table "users""#]
+        );
+        assert_eq!(
+            validate_column_references("accounts.id = id", &tables),
+            vec![r#"unknown table "accounts""#]
+        );
+    }
+
+    #[test]
+    fn validation_reports_all_errors() {
+        assert_eq!(
+            validate_column_references("a + b", &[&table()]),
+            vec![
+                r#"column "a" does not exist on table "users""#,
+                r#"column "b" does not exist on table "users""#,
+            ]
+        );
+    }
+
+    #[test]
+    fn validation_reports_invalid_sql() {
+        assert_eq!(validate_column_references("$$$", &[&table()]).len(), 1);
+    }
+
+    #[test]
+    fn validates_absence_of_column_references() {
+        assert!(validate_no_column_references("now()").is_ok());
+        assert!(validate_no_column_references("'active'").is_ok());
+        assert!(validate_no_column_references("nextval('users_id_seq')").is_ok());
+        assert!(validate_no_column_references("CURRENT_TIMESTAMP").is_ok());
+        assert_eq!(
+            validate_no_column_references("lower(name)"),
+            Err(r#"column references are not allowed here, found "name""#.to_string())
+        );
+        assert!(validate_no_column_references("$$$").is_err());
     }
 
     #[test]

--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -331,6 +331,190 @@ fn add_column_generated_identity() {
 }
 
 #[test]
+fn add_column_default_with_column_reference() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "add_column"
+        table = "users"
+        [actions.column]
+        name = "name_copy"
+        type = "TEXT"
+        default = "lower(name)"
+        "#,
+    );
+}
+
+#[test]
+fn add_column_up_invalid_column_reference() {
+    let mut test = Test::new("Add column with invalid up reference");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_column_with_bad_reference"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+        up = "UPPER(non_existent)"
+
+            [actions.column]
+            name = "upper_name"
+            type = "TEXT"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
+fn add_column_complex_up_invalid_column_reference() {
+    let mut test = Test::new("Add column with invalid cross-table up reference");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+        "#,
+    );
+
+    // `where` may reference both tables but `value` references a column which exists on
+    // neither
+    test.second_migration(
+        r#"
+        name = "add_column_with_bad_reference"
+
+        [[actions]]
+        type = "add_column"
+        table = "profiles"
+
+            [actions.column]
+            name = "name"
+            type = "TEXT"
+
+            [actions.up]
+            table = "users"
+            value = "users.non_existent"
+            where = "user_id = id"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
+fn add_column_up_references_column_added_earlier() {
+    let mut test = Test::new("Add column referencing column added in same migration");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    // `display_name` references `nickname` which is added by the previous action and
+    // only exists as a temporary column at this point
+    test.second_migration(
+        r#"
+        name = "add_nickname_and_display_name"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+        up = "LOWER(name)"
+
+            [actions.column]
+            name = "nickname"
+            type = "TEXT"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+        up = "COALESCE(nickname, name)"
+
+            [actions.column]
+            name = "display_name"
+            type = "TEXT"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, name) VALUES (1, 'John')")
+            .unwrap();
+    });
+
+    test.intermediate(|_old_db, new_db| {
+        let display_name: String = new_db
+            .query_one("SELECT display_name FROM users WHERE id = 1", &[])
+            .unwrap()
+            .get("display_name");
+        assert_eq!("john", display_name);
+    });
+
+    test.run();
+}
+
+#[test]
 fn add_column_with_default() {
     let mut test = Test::new("Add column with default value");
 

--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -450,6 +450,66 @@ fn add_column_complex_up_invalid_column_reference() {
 }
 
 #[test]
+fn add_column_complex_up_unqualified_reference() {
+    let mut test = Test::new("Add column with unqualified cross-table reference");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+        "#,
+    );
+
+    // `user_id` exists on `profiles` but resolves to the wrong table in one of the two
+    // triggers, so it has to be qualified
+    test.second_migration(
+        r#"
+        name = "add_column_with_unqualified_reference"
+
+        [[actions]]
+        type = "add_column"
+        table = "profiles"
+
+            [actions.column]
+            name = "name"
+            type = "TEXT"
+
+            [actions.up]
+            table = "users"
+            value = "users.name"
+            where = "user_id = users.id"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
 fn add_column_up_references_column_added_earlier() {
     let mut test = Test::new("Add column referencing column added in same migration");
 

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -839,6 +839,47 @@ fn add_index_referencing_renamed_column() {
 }
 
 #[test]
+fn add_index_expression_referencing_unknown_column() {
+    let mut test = Test::new("Add index expression referencing an unknown column");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_index_with_bad_expression"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_lower_idx"
+            columns = [{ expression = "lower(non_existent)" }]
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
 fn add_index_referencing_unknown_column() {
     let mut test = Test::new("Add index referencing an unknown column");
 

--- a/tests/alter_column.rs
+++ b/tests/alter_column.rs
@@ -45,6 +45,174 @@ fn alter_column_invalid_default_sql() {
 }
 
 #[test]
+fn alter_column_default_with_column_reference() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "name"
+        [actions.changes]
+        default = "lower(name)"
+        "#,
+    );
+}
+
+#[test]
+fn alter_column_up_invalid_column_reference() {
+    let mut test = Test::new("Alter column with invalid up reference");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "alter_column_with_bad_reference"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "name"
+        up = "UPPER(non_existent)"
+        down = "name"
+
+            [actions.changes]
+            type = "VARCHAR(255)"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
+fn alter_column_down_invalid_column_reference() {
+    let mut test = Test::new("Alter column with invalid down reference");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "alter_column_with_bad_reference"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "name"
+        up = "name"
+        down = "non_existent"
+
+            [actions.changes]
+            type = "VARCHAR(255)"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
+fn alter_column_rename_down_uses_old_name() {
+    let mut test = Test::new("Alter column rename with down using old name");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    // The column is available under its old name in both `up` and `down`, even though it
+    // is exposed under the new name in the new schema
+    test.second_migration(
+        r#"
+        name = "rename_name_to_full_name"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "name"
+        up = "UPPER(name)"
+        down = "LOWER(name)"
+
+            [actions.changes]
+            name = "full_name"
+            type = "VARCHAR(255)"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, name) VALUES (1, 'john')")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        let full_name: String = new_db
+            .query_one("SELECT full_name FROM users WHERE id = 1", &[])
+            .unwrap()
+            .get("full_name");
+        assert_eq!("JOHN", full_name);
+
+        new_db
+            .simple_query("INSERT INTO users (id, full_name) VALUES (2, 'JANE')")
+            .unwrap();
+        let name: String = old_db
+            .query_one("SELECT name FROM users WHERE id = 2", &[])
+            .unwrap()
+            .get("name");
+        assert_eq!("jane", name);
+    });
+
+    test.run();
+}
+
+#[test]
 fn alter_column_data() {
     let mut test = Test::new("Alter column");
 
@@ -765,10 +933,7 @@ fn alter_column_rename_and_change_type() {
         let expected = vec!["10.00", "2.50"];
         assert!(
             new_db
-                .query(
-                    "SELECT balance_amount::TEXT FROM accounts ORDER BY id",
-                    &[],
-                )
+                .query("SELECT balance_amount::TEXT FROM accounts ORDER BY id", &[],)
                 .unwrap()
                 .iter()
                 .map(|row| row.get::<_, String>("balance_amount"))

--- a/tests/create_table.rs
+++ b/tests/create_table.rs
@@ -130,6 +130,116 @@ fn create_table_up_values_invalid_column_reference() {
 }
 
 #[test]
+fn create_table_then_change_it_in_same_migration() {
+    let mut test = Test::new("Create table and change it in the same migration");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    // Every action after the first references columns of the table created by it, some
+    // of which are added or altered by the actions in between. All of them resolve
+    // through the schema as it looks right before each action.
+    test.second_migration(
+        r#"
+        name = "create_and_change_profiles"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+            nullable = false
+
+            [[actions.checks]]
+            expression = "length(email) > 0"
+
+        [[actions]]
+        type = "add_column"
+        table = "profiles"
+        up = "lower(email)"
+
+            [actions.column]
+            name = "normalized_email"
+            type = "TEXT"
+
+        [[actions]]
+        type = "alter_column"
+        table = "profiles"
+        column = "email"
+        up = "email"
+        down = "email"
+
+            [actions.changes]
+            type = "VARCHAR(255)"
+
+        [[actions]]
+        type = "add_index"
+        table = "profiles"
+
+            [actions.index]
+            name = "profiles_email_idx"
+            columns = [{ expression = "lower(normalized_email)" }]
+            where = "email IS NOT NULL"
+        "#,
+    );
+
+    test.intermediate(|_old_db, new_db| {
+        // The old schema has no `profiles` table, so all writes come from the new schema
+        new_db
+            .simple_query(
+                "INSERT INTO profiles (id, email, normalized_email) VALUES (1, 'John@Example.com', 'john@example.com')",
+            )
+            .unwrap();
+        let normalized: Option<String> = new_db
+            .query_one("SELECT normalized_email FROM profiles WHERE id = 1", &[])
+            .unwrap()
+            .get("normalized_email");
+        assert_eq!(Some("john@example.com".to_string()), normalized);
+
+        // The check constraint from the create_table action is in place
+        assert!(new_db
+            .simple_query("INSERT INTO profiles (id, email) VALUES (2, '')")
+            .is_err());
+    });
+
+    test.after_completion(|db| {
+        let definition: String = db
+            .query_one(
+                "SELECT indexdef FROM pg_indexes WHERE indexname = 'profiles_email_idx'",
+                &[],
+            )
+            .unwrap()
+            .get("indexdef");
+        assert!(
+            definition.contains("lower(normalized_email)") && !definition.contains("__reshape"),
+            "got: {}",
+            definition
+        );
+    });
+
+    test.run();
+}
+
+#[test]
 fn create_table_invalid_up_values_sql() {
     assert_invalid_sql(
         r#"

--- a/tests/create_table.rs
+++ b/tests/create_table.rs
@@ -42,6 +42,94 @@ fn create_table_invalid_check_sql() {
 }
 
 #[test]
+fn create_table_default_with_column_reference() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+        [[actions.columns]]
+        name = "id"
+        type = "INTEGER"
+        [[actions.columns]]
+        name = "name"
+        type = "TEXT"
+        default = "lower(id)"
+        "#,
+    );
+}
+
+#[test]
+fn create_table_check_invalid_column_reference() {
+    assert_invalid_sql(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+        [[actions.columns]]
+        name = "id"
+        type = "INTEGER"
+        [[actions.checks]]
+        expression = "non_existent > 0"
+        "#,
+    );
+}
+
+#[test]
+fn create_table_up_values_invalid_column_reference() {
+    let mut test = Test::new("Create table with invalid up reference");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "create_profiles_with_bad_reference"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+            [actions.up]
+            table = "users"
+            values = { id = "id", name = "non_existent" }
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
 fn create_table_invalid_up_values_sql() {
     assert_invalid_sql(
         r#"

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -50,6 +50,85 @@ fn remove_column_invalid_complex_down_where_sql() {
 }
 
 #[test]
+fn remove_column_down_invalid_column_reference() {
+    let mut test = Test::new("Remove column with invalid down reference");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "remove_name_with_bad_reference"
+
+        [[actions]]
+        type = "remove_column"
+        table = "users"
+        column = "name"
+        down = "non_existent"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
+fn remove_column_down_references_removed_column() {
+    let mut test = Test::new("Remove column with down referencing removed column");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+
+        "#,
+    );
+
+    // `down` computes the value of the removed column, so it can't reference it
+    test.second_migration(
+        r#"
+        name = "remove_name_referencing_itself"
+
+        [[actions]]
+        type = "remove_column"
+        table = "users"
+        column = "name"
+        down = "UPPER(name)"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
 fn remove_column() {
     let mut test = Test::new("Remove column");
 


### PR DESCRIPTION
Rebuilt on top of #50.

## Summary

Every SQL field in a migration file now has its column references checked, using the resolver from #47. A bad reference fails the migration with a message like:

```
Invalid SQL in field 'up': column "non_existent" does not exist on table "users"
  SQL: UPPER(non_existent)
```

instead of a Postgres error from inside a generated trigger, or worse, a trigger that only blows up when the first row is written.

## How it works

`SqlField` gains a `references` value describing what its SQL may reference:

| `References` | Meaning |
|---|---|
| `Unchecked` | statements in `custom`; syntax only |
| `Forbidden` | default values, which Postgres never allows column references in |
| `Table(scope)` | columns of one table, referenced with or without the table name |
| `CrossTable(a, b)` | the two tables of a cross-table transformation; every reference must be qualified |

Each `TableScope` is either `Schema`, a table name resolved through the schema tracker right before the action runs, optionally excluding columns, or `Explicit`, a table with its columns known up front, used for check constraints on a table which is being created and so doesn't exist yet.

`validate_sql` checks syntax plus every reference that needs no schema, so `reshape migration check` covers `Forbidden` and explicit tables offline. `validate_sql_against_schema`, called from `migrate()`, additionally resolves schema tables. Actions only declare names and exclusions.

### Why cross-table references must be qualified

The `value` and `where` of a cross-table transformation are interpolated into two triggers, one on each table. The source-side trigger runs an UPDATE on the target table, the target-side trigger runs a SELECT from the source table, so an unqualified column name resolves to a different table in each. Verified against Postgres: the fully qualified form works in both directions, a mixed form like `where = "user_id = users.id"` works on backfill but fails in the reverse trigger, and the fully unqualified form fails immediately. The validator now rejects any unqualified reference when two tables are in scope. The README example that used unqualified names could never have run and is corrected.

The scopes follow the PL/pgSQL each action generates:

| Field | May reference |
|---|---|
| `add_column.up` | the table; for cross-table `up`, the source table and the table, qualified |
| `alter_column.up` / `down` | the table, with the altered column under its current name in both, even when renaming |
| `remove_column.down` | the table minus the removed column; cross-table `down` adds the source table, qualified |
| `create_table.checks` | the new table's own columns |
| `create_table.up.values` | the source table |
| `add_index` expressions and `where` | the table |

## Test plan

- [x] Resolver unit tests for single and two-table resolution, the qualification requirement, qualified mismatches, unknown tables, error collection, and the no-references check
- [x] Failing migrations: bad `up` on `add_column`, bad cross-table `value`, unqualified cross-table `where`, bad `up` and `down` on `alter_column`, bad `down` on `remove_column`, `down` referencing the removed column, bad `up.values` on `create_table`, bad index expression
- [x] Passing migrations that exercise the tricky scopes: `add_column` referencing a column added by the previous action in the same migration, and an `alter_column` rename whose `down` uses the old name with data flowing both ways
- [x] Static checks via `assert_invalid_sql`: defaults referencing columns on all three actions, check constraint on unknown column
- [x] Full suite green, `cargo clippy -- -D warnings` clean