### PR TITLE
Validate SQL centrally instead of in each action

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    migrations::{quote_string_literal, Migration, MigrationContext},
+    migrations::{quote_string_literal, validate_sql, Migration, MigrationContext},
     schema::Schema,
 };
 
@@ -278,12 +278,12 @@ fn migrate(
             print!("  + {} ", description);
 
             // Validate SQL before running action
-            let validation_errors = action.validate_sql();
+            let validation_errors = validate_sql(action.as_ref());
             if !validation_errors.is_empty() {
-                for (field, sql, error) in &validation_errors {
+                for error in &validation_errors {
                     println!(
                         "\n    Invalid SQL in field '{}': {}\n      SQL: {}",
-                        field, error, sql
+                        error.field, error.message, error.sql
                     );
                 }
                 result = Err(anyhow!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::Context;
 use clap::{Args, Parser};
 use reshape::{
-    migrations::{Action, Migration},
+    migrations::{validate_sql, Action, Migration},
     Reshape,
 };
 use serde::{Deserialize, Serialize};
@@ -25,10 +25,7 @@ enum Command {
     #[clap(subcommand)]
     Migration(MigrationCommand),
 
-    #[clap(
-        about = "Display documentation for coding agents",
-        display_order = 0
-    )]
+    #[clap(about = "Display documentation for coding agents", display_order = 0)]
     Docs(DocsOptions),
 
     #[clap(about = "Check the current migration status", display_order = 1)]
@@ -228,11 +225,11 @@ fn run(opts: Opts) -> anyhow::Result<()> {
             let mut has_errors = false;
             for migration in &migrations {
                 for (idx, action) in migration.actions.iter().enumerate() {
-                    for (field, sql, error) in action.validate_sql() {
+                    for error in validate_sql(action.as_ref()) {
                         has_errors = true;
                         println!(
                             "Invalid SQL in '{}' action {} field '{}': {}\n  SQL: {}",
-                            migration.name, idx, field, error, sql
+                            migration.name, idx, error.field, error.message, error.sql
                         );
                     }
                 }

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -1,4 +1,4 @@
-use super::{common, quote_string_literal, Action, Column, MigrationContext, SqlExpression};
+use super::{common, quote_string_literal, Action, Column, MigrationContext, SqlField};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -443,24 +443,24 @@ impl Action for AddColumn {
         Ok(())
     }
 
-    fn sql_expressions(&self) -> Vec<SqlExpression> {
-        let mut expressions = vec![];
+    fn sql_fields(&self) -> Vec<SqlField> {
+        let mut fields = vec![];
 
         match &self.up {
             Some(Transformation::Simple(up)) => {
-                expressions.push(SqlExpression::expression("up", up));
+                fields.push(SqlField::expression("up", up));
             }
             Some(Transformation::Update { value, r#where, .. }) => {
-                expressions.push(SqlExpression::expression("up.value", value));
-                expressions.push(SqlExpression::expression("up.where", r#where));
+                fields.push(SqlField::expression("up.value", value));
+                fields.push(SqlField::expression("up.where", r#where));
             }
             None => {}
         }
 
         if let Some(default) = &self.column.default {
-            expressions.push(SqlExpression::expression("column.default", default));
+            fields.push(SqlField::expression("column.default", default));
         }
 
-        expressions
+        fields
     }
 }

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -1,4 +1,4 @@
-use super::{common, quote_string_literal, validate_sql_expression, Action, Column, MigrationContext};
+use super::{common, quote_string_literal, Action, Column, MigrationContext, SqlExpression};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -443,35 +443,24 @@ impl Action for AddColumn {
         Ok(())
     }
 
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        let mut errors = vec![];
+    fn sql_expressions(&self) -> Vec<SqlExpression> {
+        let mut expressions = vec![];
 
-        // Validate transformation
-        if let Some(up) = &self.up {
-            match up {
-                Transformation::Simple(expr) => {
-                    if let Err(e) = validate_sql_expression(expr) {
-                        errors.push(("up".to_string(), expr.clone(), e));
-                    }
-                }
-                Transformation::Update { value, r#where, .. } => {
-                    if let Err(e) = validate_sql_expression(value) {
-                        errors.push(("up.value".to_string(), value.clone(), e));
-                    }
-                    if let Err(e) = validate_sql_expression(r#where) {
-                        errors.push(("up.where".to_string(), r#where.clone(), e));
-                    }
-                }
+        match &self.up {
+            Some(Transformation::Simple(up)) => {
+                expressions.push(SqlExpression::expression("up", up));
             }
+            Some(Transformation::Update { value, r#where, .. }) => {
+                expressions.push(SqlExpression::expression("up.value", value));
+                expressions.push(SqlExpression::expression("up.where", r#where));
+            }
+            None => {}
         }
 
-        // Validate column default
         if let Some(default) = &self.column.default {
-            if let Err(e) = validate_sql_expression(default) {
-                errors.push(("column.default".to_string(), default.clone(), e));
-            }
+            expressions.push(SqlExpression::expression("column.default", default));
         }
 
-        errors
+        expressions
     }
 }

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -1,4 +1,4 @@
-use super::{Action, MigrationContext, SqlExpression};
+use super::{Action, MigrationContext, SqlField};
 use crate::{
     db::{Conn, Transaction},
     schema::{Schema, Table},
@@ -200,14 +200,14 @@ impl Action for AddIndex {
         Ok(())
     }
 
-    fn sql_expressions(&self) -> Vec<SqlExpression> {
-        let mut expressions: Vec<SqlExpression> = self
+    fn sql_fields(&self) -> Vec<SqlField> {
+        let mut fields: Vec<SqlField> = self
             .index
             .columns
             .iter()
             .enumerate()
             .filter_map(|(idx, column)| match column {
-                IndexColumn::Expression(spec) => Some(SqlExpression::expression(
+                IndexColumn::Expression(spec) => Some(SqlField::expression(
                     format!("index.columns[{}].expression", idx),
                     &spec.expression,
                 )),
@@ -216,9 +216,9 @@ impl Action for AddIndex {
             .collect();
 
         if let Some(predicate) = &self.index.r#where {
-            expressions.push(SqlExpression::expression("index.where", predicate));
+            fields.push(SqlField::expression("index.where", predicate));
         }
 
-        expressions
+        fields
     }
 }

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -1,4 +1,4 @@
-use super::{validate_sql_expression, Action, MigrationContext};
+use super::{Action, MigrationContext, SqlExpression};
 use crate::{
     db::{Conn, Transaction},
     schema::{Schema, Table},
@@ -200,29 +200,25 @@ impl Action for AddIndex {
         Ok(())
     }
 
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        let mut errors = vec![];
+    fn sql_expressions(&self) -> Vec<SqlExpression> {
+        let mut expressions: Vec<SqlExpression> = self
+            .index
+            .columns
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, column)| match column {
+                IndexColumn::Expression(spec) => Some(SqlExpression::expression(
+                    format!("index.columns[{}].expression", idx),
+                    &spec.expression,
+                )),
+                _ => None,
+            })
+            .collect();
 
-        // Validate index expressions
-        for (idx, column) in self.index.columns.iter().enumerate() {
-            if let IndexColumn::Expression(spec) = column {
-                if let Err(e) = validate_sql_expression(&spec.expression) {
-                    errors.push((
-                        format!("index.columns[{}].expression", idx),
-                        spec.expression.clone(),
-                        e,
-                    ));
-                }
-            }
-        }
-
-        // Validate partial index predicate
         if let Some(predicate) = &self.index.r#where {
-            if let Err(e) = validate_sql_expression(predicate) {
-                errors.push(("index.where".to_string(), predicate.clone(), e));
-            }
+            expressions.push(SqlExpression::expression("index.where", predicate));
         }
 
-        errors
+        expressions
     }
 }

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -1,4 +1,4 @@
-use super::{Action, MigrationContext, SqlExpression};
+use super::{Action, MigrationContext, SqlField};
 use crate::{
     db::{Conn, Transaction},
     migrations::common,
@@ -436,7 +436,7 @@ impl Action for AlterColumn {
         Ok(())
     }
 
-    fn sql_expressions(&self) -> Vec<SqlExpression> {
+    fn sql_fields(&self) -> Vec<SqlField> {
         [
             ("up", &self.up),
             ("down", &self.down),
@@ -445,7 +445,7 @@ impl Action for AlterColumn {
         .into_iter()
         .filter_map(|(field, sql)| {
             sql.as_ref()
-                .map(|sql| SqlExpression::expression(field, sql))
+                .map(|sql| SqlField::expression(field, sql))
         })
         .collect()
     }

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -1,4 +1,4 @@
-use super::{validate_sql_expression, Action, MigrationContext};
+use super::{Action, MigrationContext, SqlExpression};
 use crate::{
     db::{Conn, Transaction},
     migrations::common,
@@ -436,28 +436,18 @@ impl Action for AlterColumn {
         Ok(())
     }
 
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        let mut errors = vec![];
-
-        if let Some(up) = &self.up {
-            if let Err(e) = validate_sql_expression(up) {
-                errors.push(("up".to_string(), up.clone(), e));
-            }
-        }
-
-        if let Some(down) = &self.down {
-            if let Err(e) = validate_sql_expression(down) {
-                errors.push(("down".to_string(), down.clone(), e));
-            }
-        }
-
-        if let Some(default) = &self.changes.default {
-            if let Err(e) = validate_sql_expression(default) {
-                errors.push(("changes.default".to_string(), default.clone(), e));
-            }
-        }
-
-        errors
+    fn sql_expressions(&self) -> Vec<SqlExpression> {
+        [
+            ("up", &self.up),
+            ("down", &self.down),
+            ("changes.default", &self.changes.default),
+        ]
+        .into_iter()
+        .filter_map(|(field, sql)| {
+            sql.as_ref()
+                .map(|sql| SqlExpression::expression(field, sql))
+        })
+        .collect()
     }
 }
 

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::{
     common::{Check, ForeignKey},
-    quote_string_literal, Action, Column, MigrationContext, SqlExpression,
+    quote_string_literal, Action, Column, MigrationContext, SqlField,
 };
 use crate::{
     db::{Conn, Transaction},
@@ -272,14 +272,14 @@ impl Action for CreateTable {
         Ok(())
     }
 
-    fn sql_expressions(&self) -> Vec<SqlExpression> {
-        let mut expressions = vec![];
+    fn sql_fields(&self) -> Vec<SqlField> {
+        let mut fields = vec![];
 
         // Note: `generated` is not included as it's a column generation clause
         // (e.g., "ALWAYS AS IDENTITY"), not a SQL expression
         for (idx, column) in self.columns.iter().enumerate() {
             if let Some(default) = &column.default {
-                expressions.push(SqlExpression::expression(
+                fields.push(SqlField::expression(
                     format!("columns[{}].default", idx),
                     default,
                 ));
@@ -287,7 +287,7 @@ impl Action for CreateTable {
         }
 
         for (idx, check) in self.checks.iter().enumerate() {
-            expressions.push(SqlExpression::expression(
+            fields.push(SqlField::expression(
                 format!("checks[{}].expression", idx),
                 &check.expression,
             ));
@@ -295,13 +295,13 @@ impl Action for CreateTable {
 
         if let Some(Transformation { values, .. }) = &self.up {
             for (column, value) in values {
-                expressions.push(SqlExpression::expression(
+                fields.push(SqlField::expression(
                     format!("up.values.{}", column),
                     value,
                 ));
             }
         }
 
-        expressions
+        fields
     }
 }

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::{
     common::{Check, ForeignKey},
-    quote_string_literal, validate_sql_expression, Action, Column, MigrationContext,
+    quote_string_literal, Action, Column, MigrationContext, SqlExpression,
 };
 use crate::{
     db::{Conn, Transaction},
@@ -272,45 +272,36 @@ impl Action for CreateTable {
         Ok(())
     }
 
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        let mut errors = vec![];
+    fn sql_expressions(&self) -> Vec<SqlExpression> {
+        let mut expressions = vec![];
 
-        // Validate column defaults and generated expressions
+        // Note: `generated` is not included as it's a column generation clause
+        // (e.g., "ALWAYS AS IDENTITY"), not a SQL expression
         for (idx, column) in self.columns.iter().enumerate() {
             if let Some(default) = &column.default {
-                if let Err(e) = validate_sql_expression(default) {
-                    errors.push((
-                        format!("columns[{}].default", idx),
-                        default.clone(),
-                        e,
-                    ));
-                }
-            }
-
-            // Note: `generated` is not validated as it's a column generation clause
-            // (e.g., "ALWAYS AS IDENTITY"), not a SQL expression
-        }
-
-        // Validate check constraint expressions
-        for (idx, check) in self.checks.iter().enumerate() {
-            if let Err(e) = validate_sql_expression(&check.expression) {
-                errors.push((
-                    format!("checks[{}].expression", idx),
-                    check.expression.clone(),
-                    e,
+                expressions.push(SqlExpression::expression(
+                    format!("columns[{}].default", idx),
+                    default,
                 ));
             }
         }
 
-        // Validate transformation values
+        for (idx, check) in self.checks.iter().enumerate() {
+            expressions.push(SqlExpression::expression(
+                format!("checks[{}].expression", idx),
+                &check.expression,
+            ));
+        }
+
         if let Some(Transformation { values, .. }) = &self.up {
-            for (key, value) in values {
-                if let Err(e) = validate_sql_expression(value) {
-                    errors.push((format!("up.values.{}", key), value.clone(), e));
-                }
+            for (column, value) in values {
+                expressions.push(SqlExpression::expression(
+                    format!("up.values.{}", column),
+                    value,
+                ));
             }
         }
 
-        errors
+        expressions
     }
 }

--- a/src/migrations/custom.rs
+++ b/src/migrations/custom.rs
@@ -1,4 +1,4 @@
-use super::{validate_sql_statement, Action, MigrationContext};
+use super::{Action, MigrationContext, SqlExpression};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -59,27 +59,14 @@ impl Action for Custom {
         Ok(())
     }
 
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        let mut errors = vec![];
-
-        if let Some(start) = &self.start {
-            if let Err(e) = validate_sql_statement(start) {
-                errors.push(("start".to_string(), start.clone(), e));
-            }
-        }
-
-        if let Some(complete) = &self.complete {
-            if let Err(e) = validate_sql_statement(complete) {
-                errors.push(("complete".to_string(), complete.clone(), e));
-            }
-        }
-
-        if let Some(abort) = &self.abort {
-            if let Err(e) = validate_sql_statement(abort) {
-                errors.push(("abort".to_string(), abort.clone(), e));
-            }
-        }
-
-        errors
+    fn sql_expressions(&self) -> Vec<SqlExpression> {
+        [
+            ("start", &self.start),
+            ("complete", &self.complete),
+            ("abort", &self.abort),
+        ]
+        .into_iter()
+        .filter_map(|(field, sql)| sql.as_ref().map(|sql| SqlExpression::statement(field, sql)))
+        .collect()
     }
 }

--- a/src/migrations/custom.rs
+++ b/src/migrations/custom.rs
@@ -1,4 +1,4 @@
-use super::{Action, MigrationContext, SqlExpression};
+use super::{Action, MigrationContext, SqlField};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -59,14 +59,14 @@ impl Action for Custom {
         Ok(())
     }
 
-    fn sql_expressions(&self) -> Vec<SqlExpression> {
+    fn sql_fields(&self) -> Vec<SqlField> {
         [
             ("start", &self.start),
             ("complete", &self.complete),
             ("abort", &self.abort),
         ]
         .into_iter()
-        .filter_map(|(field, sql)| sql.as_ref().map(|sql| SqlExpression::statement(field, sql)))
+        .filter_map(|(field, sql)| sql.as_ref().map(|sql| SqlField::statement(field, sql)))
         .collect()
     }
 }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -5,12 +5,12 @@ use crate::{
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
-/// A piece of user-provided SQL in an action, such as an `up` expression or a statement
-/// in a custom action
+/// A field of an action which holds user-provided SQL, such as the `up` of `add_column`
+/// or the `start` of a custom action
 #[derive(Debug, Clone)]
-pub struct SqlExpression {
-    /// The field the SQL was read from, used in error messages, e.g. "up" or "column.default"
-    pub field: String,
+pub struct SqlField {
+    /// The name of the field, used in error messages, e.g. "up" or "column.default"
+    pub name: String,
     pub sql: String,
     pub kind: SqlKind,
 }
@@ -23,18 +23,18 @@ pub enum SqlKind {
     Statement,
 }
 
-impl SqlExpression {
-    pub fn expression(field: impl Into<String>, sql: impl Into<String>) -> Self {
-        SqlExpression {
-            field: field.into(),
+impl SqlField {
+    pub fn expression(name: impl Into<String>, sql: impl Into<String>) -> Self {
+        SqlField {
+            name: name.into(),
             sql: sql.into(),
             kind: SqlKind::Expression,
         }
     }
 
-    pub fn statement(field: impl Into<String>, sql: impl Into<String>) -> Self {
-        SqlExpression {
-            field: field.into(),
+    pub fn statement(name: impl Into<String>, sql: impl Into<String>) -> Self {
+        SqlField {
+            name: name.into(),
             sql: sql.into(),
             kind: SqlKind::Statement,
         }
@@ -52,17 +52,17 @@ pub struct SqlError {
 /// Validates all user-provided SQL in an action
 pub fn validate_sql(action: &dyn Action) -> Vec<SqlError> {
     action
-        .sql_expressions()
+        .sql_fields()
         .into_iter()
-        .filter_map(|expression| {
-            let result = match expression.kind {
-                SqlKind::Expression => crate::sql::validate_sql_expression(&expression.sql),
-                SqlKind::Statement => crate::sql::validate_sql_statement(&expression.sql),
+        .filter_map(|field| {
+            let result = match field.kind {
+                SqlKind::Expression => crate::sql::validate_sql_expression(&field.sql),
+                SqlKind::Statement => crate::sql::validate_sql_statement(&field.sql),
             };
 
             result.err().map(|message| SqlError {
-                field: expression.field,
-                sql: expression.sql,
+                field: field.name,
+                sql: field.sql,
                 message,
             })
         })
@@ -205,7 +205,7 @@ pub trait Action: Debug {
     fn abort(&self, ctx: &MigrationContext, db: &mut dyn Conn) -> anyhow::Result<()>;
 
     /// User-provided SQL in the action, which is validated before the action runs
-    fn sql_expressions(&self) -> Vec<SqlExpression> {
+    fn sql_fields(&self) -> Vec<SqlField> {
         vec![]
     }
 }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -5,11 +5,9 @@ use crate::{
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
-/// A field of an action which holds user-provided SQL, such as the `up` of `add_column`
-/// or the `start` of a custom action
+/// A field of an action which holds user-provided SQL
 #[derive(Debug, Clone)]
 pub struct SqlField {
-    /// The name of the field, used in error messages, e.g. "up" or "column.default"
     pub name: String,
     pub sql: String,
     pub kind: SqlKind,
@@ -17,9 +15,9 @@ pub struct SqlField {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqlKind {
-    /// An expression evaluating to a value, for example the `up` of `add_column`
+    /// An expression evaluating to a value
     Expression,
-    /// One or more complete statements, for example the `start` of `custom`
+    /// One or more complete statements
     Statement,
 }
 
@@ -49,7 +47,6 @@ pub struct SqlError {
     pub message: String,
 }
 
-/// Validates all user-provided SQL in an action
 pub fn validate_sql(action: &dyn Action) -> Vec<SqlError> {
     action
         .sql_fields()

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -5,7 +5,69 @@ use crate::{
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
-pub use crate::sql::{validate_sql_expression, validate_sql_statement};
+/// A piece of user-provided SQL in an action, such as an `up` expression or a statement
+/// in a custom action
+#[derive(Debug, Clone)]
+pub struct SqlExpression {
+    /// The field the SQL was read from, used in error messages, e.g. "up" or "column.default"
+    pub field: String,
+    pub sql: String,
+    pub kind: SqlKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlKind {
+    /// An expression evaluating to a value, for example the `up` of `add_column`
+    Expression,
+    /// One or more complete statements, for example the `start` of `custom`
+    Statement,
+}
+
+impl SqlExpression {
+    pub fn expression(field: impl Into<String>, sql: impl Into<String>) -> Self {
+        SqlExpression {
+            field: field.into(),
+            sql: sql.into(),
+            kind: SqlKind::Expression,
+        }
+    }
+
+    pub fn statement(field: impl Into<String>, sql: impl Into<String>) -> Self {
+        SqlExpression {
+            field: field.into(),
+            sql: sql.into(),
+            kind: SqlKind::Statement,
+        }
+    }
+}
+
+/// An error found in user-provided SQL
+#[derive(Debug, Clone)]
+pub struct SqlError {
+    pub field: String,
+    pub sql: String,
+    pub message: String,
+}
+
+/// Validates all user-provided SQL in an action
+pub fn validate_sql(action: &dyn Action) -> Vec<SqlError> {
+    action
+        .sql_expressions()
+        .into_iter()
+        .filter_map(|expression| {
+            let result = match expression.kind {
+                SqlKind::Expression => crate::sql::validate_sql_expression(&expression.sql),
+                SqlKind::Statement => crate::sql::validate_sql_statement(&expression.sql),
+            };
+
+            result.err().map(|message| SqlError {
+                field: expression.field,
+                sql: expression.sql,
+                message,
+            })
+        })
+        .collect()
+}
 
 /// Quote a value so it can be used as an SQL string literal.
 ///
@@ -142,8 +204,8 @@ pub trait Action: Debug {
     fn update_schema(&self, ctx: &MigrationContext, schema: &mut Schema);
     fn abort(&self, ctx: &MigrationContext, db: &mut dyn Conn) -> anyhow::Result<()>;
 
-    /// Validate user-provided SQL. Returns list of (field_name, sql, error_message).
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        vec![] // Default: no SQL to validate
+    /// User-provided SQL in the action, which is validated before the action runs
+    fn sql_expressions(&self) -> Vec<SqlExpression> {
+        vec![]
     }
 }

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -1,4 +1,4 @@
-use super::{common, Action, MigrationContext, SqlExpression};
+use super::{common, Action, MigrationContext, SqlField};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -452,12 +452,12 @@ impl Action for RemoveColumn {
         Ok(())
     }
 
-    fn sql_expressions(&self) -> Vec<SqlExpression> {
+    fn sql_fields(&self) -> Vec<SqlField> {
         match &self.down {
-            Some(Transformation::Simple(down)) => vec![SqlExpression::expression("down", down)],
+            Some(Transformation::Simple(down)) => vec![SqlField::expression("down", down)],
             Some(Transformation::Update { value, r#where, .. }) => vec![
-                SqlExpression::expression("down.value", value),
-                SqlExpression::expression("down.where", r#where),
+                SqlField::expression("down.value", value),
+                SqlField::expression("down.where", r#where),
             ],
             None => vec![],
         }

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -1,4 +1,4 @@
-use super::{common, validate_sql_expression, Action, MigrationContext};
+use super::{common, Action, MigrationContext, SqlExpression};
 use crate::{
     db::{Conn, Transaction},
     schema::Schema,
@@ -452,27 +452,14 @@ impl Action for RemoveColumn {
         Ok(())
     }
 
-    fn validate_sql(&self) -> Vec<(String, String, String)> {
-        let mut errors = vec![];
-
-        if let Some(down) = &self.down {
-            match down {
-                Transformation::Simple(expr) => {
-                    if let Err(e) = validate_sql_expression(expr) {
-                        errors.push(("down".to_string(), expr.clone(), e));
-                    }
-                }
-                Transformation::Update { value, r#where, .. } => {
-                    if let Err(e) = validate_sql_expression(value) {
-                        errors.push(("down.value".to_string(), value.clone(), e));
-                    }
-                    if let Err(e) = validate_sql_expression(r#where) {
-                        errors.push(("down.where".to_string(), r#where.clone(), e));
-                    }
-                }
-            }
+    fn sql_expressions(&self) -> Vec<SqlExpression> {
+        match &self.down {
+            Some(Transformation::Simple(down)) => vec![SqlExpression::expression("down", down)],
+            Some(Transformation::Update { value, r#where, .. }) => vec![
+                SqlExpression::expression("down.value", value),
+                SqlExpression::expression("down.where", r#where),
+            ],
+            None => vec![],
         }
-
-        errors
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,11 +1,18 @@
 use colored::Colorize;
 use postgres::Client;
 use postgres_native_tls::MakeTlsConnector;
-use reshape::{migrations::Migration, Reshape};
+use reshape::{
+    migrations::{validate_sql, Migration},
+    Reshape,
+};
 
 pub fn assert_invalid_sql(toml: &str) {
     let migration: Migration = toml::from_str(toml).unwrap();
-    let errors: Vec<_> = migration.actions.iter().flat_map(|a| a.validate_sql()).collect();
+    let errors: Vec<_> = migration
+        .actions
+        .iter()
+        .flat_map(|action| validate_sql(action.as_ref()))
+        .collect();
     assert!(!errors.is_empty(), "expected SQL validation to fail");
 }
 


### PR DESCRIPTION
## Summary

Every action implemented `validate_sql` the same way: collect its SQL fields, run the syntax check on each, build a list of `(field, sql, error)` tuples. This refactor moves the checking into one place.

- Actions now implement `sql_fields()`, returning a `SqlField` per field holding SQL: the field name for error messages, the SQL, and whether it is an expression or a complete statement. That is all an action needs to know.
- A single `migrations::validate_sql(action)` runs the appropriate syntax check and returns `SqlError` values with named fields instead of tuples.
- `migrate()`, `reshape migration check` and the test helper call the central function.

No behavior changes. Same fields are validated, same messages are printed.

## Why

Validation of the columns an expression references (#48) is next, and with this shape it becomes extra metadata on `SqlField` checked centrally, rather than a second per-action hook alongside `validate_sql`. I'll rework #48 on top of this once it's in.

## Test plan

- [x] Full suite green, including every existing invalid-SQL test for all six actions
- [x] `cargo clippy -- -D warnings` clean