### PR TITLE
Fail on references to columns and tables the schema doesn't have

### DIFF
--- a/src/migrations/add_foreign_key.rs
+++ b/src/migrations/add_foreign_key.rs
@@ -32,11 +32,13 @@ impl Action for AddForeignKey {
 
         // Add quotes around all column names
         let columns: Vec<String> = table
-            .real_column_names(&self.foreign_key.columns)
+            .real_column_names(&self.foreign_key.columns)?
+            .iter()
             .map(|col| format!("\"{}\"", col))
             .collect();
         let referenced_columns: Vec<String> = referenced_table
-            .real_column_names(&self.foreign_key.referenced_columns)
+            .real_column_names(&self.foreign_key.referenced_columns)?
+            .iter()
             .map(|col| format!("\"{}\"", col))
             .collect();
 

--- a/src/migrations/add_index.rs
+++ b/src/migrations/add_index.rs
@@ -96,9 +96,11 @@ impl Index {
             .iter()
             .map(|column| {
                 let (target, direction, nulls) = match column {
-                    IndexColumn::Name(name) => (real_column_name(table, name), &None, &None),
+                    IndexColumn::Name(name) => {
+                        (quoted_real_column_name(table, name)?, &None, &None)
+                    }
                     IndexColumn::Column(spec) => (
-                        real_column_name(table, &spec.column),
+                        quoted_real_column_name(table, &spec.column)?,
                         &spec.direction,
                         &spec.nulls,
                     ),
@@ -133,13 +135,8 @@ impl Index {
     }
 }
 
-fn real_column_name(table: &Table, name: &str) -> String {
-    let real_name = table
-        .get_column(name)
-        .map(|column| column.real_name.as_ref())
-        .unwrap_or(name);
-
-    format!("\"{}\"", real_name)
+fn quoted_real_column_name(table: &Table, name: &str) -> anyhow::Result<String> {
+    Ok(format!("\"{}\"", table.real_column_name(name)?))
 }
 
 #[typetag::serde(name = "add_index")]

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -116,7 +116,8 @@ impl Action for CreateTable {
 
             let referenced_table = schema.get_table(db, &foreign_key.referenced_table)?;
             let referenced_columns: Vec<String> = referenced_table
-                .real_column_names(&foreign_key.referenced_columns)
+                .real_column_names(&foreign_key.referenced_columns)?
+                .iter()
                 .map(|col| format!("\"{}\"", col))
                 .collect();
 

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -206,12 +206,9 @@ fn validate_references_against_schema(
                 table,
                 excluded_columns,
             } => {
-                let mut resolved = schema.get_table(db, table)?;
-
-                // A table which doesn't exist comes back without any columns
-                if resolved.columns.is_empty() {
+                let Some(mut resolved) = schema.find_table(db, table)? else {
                     return Ok(Err(format!("table \"{}\" does not exist", table)));
-                }
+                };
 
                 resolved
                     .columns

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,5 @@
 use crate::db::Conn;
+use anyhow::anyhow;
 use std::collections::{HashMap, HashSet};
 
 // Schema tracks changes made to tables and columns during a migration.
@@ -184,16 +185,55 @@ impl Schema {
     }
 
     pub fn get_table(&self, db: &mut dyn Conn, table_name: &str) -> anyhow::Result<Table> {
+        self.find_table(db, table_name)?
+            .ok_or_else(|| anyhow!("table \"{}\" does not exist", table_name))
+    }
+
+    /// Looks up a table by its current name. Returns `None` if the schema has no such
+    /// table, either because it doesn't exist in the database, because it has been
+    /// removed or because the name is one it no longer has.
+    pub fn find_table(&self, db: &mut dyn Conn, table_name: &str) -> anyhow::Result<Option<Table>> {
         let table_changes = self
             .table_changes
             .iter()
             .find(|changes| changes.current_name == table_name);
 
-        let real_table_name = table_changes
-            .map(|changes| changes.real_name.to_string())
-            .unwrap_or_else(|| table_name.to_string());
+        let real_table_name = match table_changes {
+            Some(changes) if changes.removed => return Ok(None),
+            Some(changes) => changes.real_name.to_string(),
+            None => {
+                // The name may be the old name of a table which has been renamed. The
+                // real table still exists until the migration completes, but it's no
+                // longer known by that name.
+                let renamed = self.table_changes.iter().any(|changes| {
+                    changes.real_name == table_name && changes.current_name != table_name
+                });
+                if renamed {
+                    return Ok(None);
+                }
 
-        self.get_table_by_real_name(db, &real_table_name)
+                table_name.to_string()
+            }
+        };
+
+        if !self.table_exists(db, &real_table_name)? {
+            return Ok(None);
+        }
+
+        self.get_table_by_real_name(db, &real_table_name).map(Some)
+    }
+
+    fn table_exists(&self, db: &mut dyn Conn, real_table_name: &str) -> anyhow::Result<bool> {
+        let rows = db.query(&format!(
+            "
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = '{table}' AND table_schema = 'public'
+            ",
+            table = real_table_name,
+        ))?;
+
+        Ok(!rows.is_empty())
     }
 
     fn get_table_by_real_name(
@@ -288,15 +328,24 @@ impl Schema {
 }
 
 impl Table {
-    pub fn real_column_names<'a>(
-        &'a self,
-        columns: &'a [String],
-    ) -> impl Iterator<Item = &'a String> {
-        columns.iter().map(|name| {
-            self.get_column(name)
-                .map(|col| &col.real_name)
-                .unwrap_or(name)
-        })
+    /// The name of the real column backing a column, failing if the column doesn't exist
+    pub fn real_column_name(&self, name: &str) -> anyhow::Result<&str> {
+        self.get_column(name)
+            .map(|column| column.real_name.as_str())
+            .ok_or_else(|| {
+                anyhow!(
+                    "column \"{}\" does not exist on table \"{}\"",
+                    name,
+                    self.name
+                )
+            })
+    }
+
+    pub fn real_column_names(&self, columns: &[String]) -> anyhow::Result<Vec<String>> {
+        columns
+            .iter()
+            .map(|name| self.real_column_name(name).map(str::to_string))
+            .collect()
     }
 
     pub fn get_column(&self, name: &str) -> Option<&Column> {

--- a/tests/add_foreign_key.rs
+++ b/tests/add_foreign_key.rs
@@ -167,6 +167,114 @@ fn add_invalid_foreign_key() {
 }
 
 #[test]
+fn add_foreign_key_with_unknown_column() {
+    let mut test = Test::new("Add foreign key on an unknown column");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+        [[actions]]
+        type = "create_table"
+        name = "items"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_foreign_key"
+
+        [[actions]]
+        type = "add_foreign_key"
+        table = "items"
+
+            [actions.foreign_key]
+            columns = ["owner_id"]
+            referenced_table = "users"
+            referenced_columns = ["id"]
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
+fn add_foreign_key_to_removed_table() {
+    let mut test = Test::new("Add foreign key to a table removed in the same migration");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+        [[actions]]
+        type = "create_table"
+        name = "items"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+        "#,
+    );
+
+    // The table still exists until the migration completes, so the foreign key could be
+    // created and would then be dropped together with the table
+    test.second_migration(
+        r#"
+        name = "remove_users_and_add_foreign_key"
+
+        [[actions]]
+        type = "remove_table"
+        table = "users"
+
+        [[actions]]
+        type = "add_foreign_key"
+        table = "items"
+
+            [actions.foreign_key]
+            columns = ["user_id"]
+            referenced_table = "users"
+            referenced_columns = ["id"]
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
 fn add_foreign_key_with_referential_actions() {
     let mut test = Test::new("Add foreign key with referential actions");
 

--- a/tests/add_index.rs
+++ b/tests/add_index.rs
@@ -880,6 +880,105 @@ fn add_index_expression_referencing_unknown_column() {
 }
 
 #[test]
+fn add_index_with_stale_column_name() {
+    let mut test = Test::new("Add index using the old name of an altered column");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+        "#,
+    );
+
+    // The rename with a type change replaces `name` with a temporary column exposed as
+    // `full_name`. Indexing `name` would silently build the index on the old column,
+    // which is dropped on completion.
+    test.second_migration(
+        r#"
+        name = "rename_name_and_index_old_name"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "name"
+        up = "name"
+        down = "name"
+
+            [actions.changes]
+            name = "full_name"
+            type = "VARCHAR(255)"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_name_idx"
+            columns = ["name"]
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
+fn add_index_with_stale_table_name() {
+    let mut test = Test::new("Add index using the old name of a renamed table");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "rename_users_and_index_old_name"
+
+        [[actions]]
+        type = "rename_table"
+        table = "users"
+        new_name = "customers"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_name_idx"
+            columns = ["name"]
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}
+
+#[test]
 fn add_index_referencing_unknown_column() {
     let mut test = Test::new("Add index referencing an unknown column");
 


### PR DESCRIPTION
## Summary

Looking up a column or table by name fell back to the name as given when the schema tracker didn't know it. That is a correctness bug, not just a missing check: a stale name is by definition the name of something which still exists physically until the migration completes, so the lookup silently landed on the old object.

Reproduced: `alter_column` renames `name` to `full_name` with a type change, and `add_index` in the same migration indexes `["name"]`. The migration succeeds, the index is built on the old physical column, and it is gone after completion. The same applies to `add_foreign_key` and `create_table` foreign keys through the shared column helper, and to tables: `get_table` ignored the removed flag and resolved a pre-rename table name to the old physical table, so an index or foreign key on a table removed or renamed earlier in the migration was created against the doomed object.

## Fix

- `Schema::get_table` fails for a table which doesn't exist in the database, has been removed in the migration, or is referenced by a name it no longer has. A new `Schema::find_table` returns `Option` for callers that want to report the absence themselves.
- `Table::real_column_names` fails for unknown columns, with a new `real_column_name` for single lookups. `add_index`, `add_foreign_key` and `create_table` foreign keys go through these.
- SQL reference validation uses `find_table`, replacing the "no columns means no table" heuristic.

These failures happen inside `run`, which already aborts and cleans up, so a stale name now fails the migration instead of succeeding and losing the object at completion. Reporting them before anything runs, alongside the SQL checks, is the follow-up PR.

## Test plan

- [x] `add_index_with_stale_column_name`: the reproduction above now fails the migration
- [x] `add_index_with_stale_table_name`: indexing a table by its pre-rename name fails
- [x] `add_foreign_key_with_unknown_column` and `add_foreign_key_to_removed_table` fail
- [x] Full suite green, `cargo clippy -- -D warnings` clean