### PR TITLE
Resolve cross-table transformations through the current schema

### DIFF
--- a/src/docs/actions/add-column.md
+++ b/src/docs/actions/add-column.md
@@ -137,6 +137,5 @@ table = "products"
 
 - For non-nullable columns, provide either `default` or `up` to populate existing rows
 - The `up` expression is evaluated for each row during backfill
-- Cross-table `up` requires a previous migration schema to exist
 - In a cross-table `up`, every column in `value` and `where` must be qualified with its
   table name, as the expressions run in triggers on both tables

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,8 +297,7 @@ fn migrate(
                 break 'outer;
             }
 
-            let ctx =
-                MigrationContext::new(migration_index, action_index, state::current_migration(db)?);
+            let ctx = MigrationContext::new(migration_index, action_index);
             result = action
                 .run(&ctx, db, &new_schema)
                 .with_context(|| format!("failed to {}", description));
@@ -408,8 +407,7 @@ fn complete(db: &mut DbConn, state: &mut State) -> anyhow::Result<()> {
             let description = action.describe();
             print!("  + {} ", description);
 
-            let ctx =
-                MigrationContext::new(migration_index, action_index, state::current_migration(db)?);
+            let ctx = MigrationContext::new(migration_index, action_index);
 
             // Update state to indicate that this action has been completed.
             // We won't save this new state until after the action has completed.
@@ -534,8 +532,7 @@ fn abort(db: &mut DbConn, state: &mut State) -> anyhow::Result<()> {
                 continue;
             }
 
-            let ctx =
-                MigrationContext::new(migration_index, action_index, state::current_migration(db)?);
+            let ctx = MigrationContext::new(migration_index, action_index);
             action
                 .abort(&ctx, db)
                 .with_context(|| format!("failed to abort migration {}", migration.name))

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -179,11 +179,6 @@ impl Action for AddColumn {
             {
                 let from_table = schema.get_table(db, from_table)?;
 
-                // Both tables are exposed with their columns under their current names, so
-                // `value` and `where` reference the schema as it looks in this migration. The
-                // table being written is a record built from the new row, the other table a
-                // subquery over the real table.
-
                 // When the source table is written in the old schema, update the matching
                 // rows of the changed table
                 let query = format!(

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -6,7 +6,7 @@ use crate::{
     db::{Conn, Transaction},
     schema::Schema,
 };
-use anyhow::{bail, Context};
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -177,27 +177,15 @@ impl Action for AddColumn {
                 r#where,
             } = up
             {
-                let existing_schema_name = match &ctx.existing_schema_name {
-                    Some(name) => name,
-                    None => bail!("can't use update without previous migration"),
-                };
-
                 let from_table = schema.get_table(db, from_table)?;
 
-                let from_table_assignments: Vec<String> = from_table
-                    .columns
-                    .iter()
-                    .map(|column| {
-                        format!(
-                            "{table}.{alias} = NEW.{real_name};",
-                            table = from_table.name,
-                            alias = column.name,
-                            real_name = column.real_name,
-                        )
-                    })
-                    .collect();
+                // Both tables are exposed with their columns under their current names, so
+                // `value` and `where` reference the schema as it looks in this migration. The
+                // table being written is a record built from the new row, the other table a
+                // subquery over the real table.
 
-                // Add triggers to fill in values as they are inserted/updated
+                // When the source table is written in the old schema, update the matching
+                // rows of the changed table
                 let query = format!(
                     r#"
                     CREATE OR REPLACE FUNCTION {trigger_name}()
@@ -206,16 +194,21 @@ impl Action for AddColumn {
                     BEGIN
                         IF NOT reshape.is_new_schema() THEN
                             DECLARE
-                                {from_table} migration_{existing_schema_name}.{from_table}%ROWTYPE;
+                                {from_table} record;
                             BEGIN
-                                {assignments}
+                                SELECT {from_table_row} INTO {from_table};
 
                                 -- Don't trigger reverse trigger when making this update
                                 perform set_config('reshape.disable_triggers', 'TRUE', TRUE);
 
-                                UPDATE public."{changed_table_real}"
-                                SET "{temp_column_name}" = {value}
-                                WHERE {where};
+                                UPDATE public."{changed_table_real}" AS __target
+                                SET "{temp_column_name}" = __values.value
+                                FROM (
+                                    SELECT "{changed_table}".ctid, ({value}) AS value
+                                    FROM {changed_table_subquery}
+                                    WHERE {where}
+                                ) __values
+                                WHERE __target.ctid = __values.ctid;
 
                                 perform set_config('reshape.disable_triggers', '', TRUE);
                             END;
@@ -227,37 +220,19 @@ impl Action for AddColumn {
                     DROP TRIGGER IF EXISTS "{trigger_name}" ON "{from_table_real}";
                     CREATE TRIGGER "{trigger_name}" BEFORE UPDATE OR INSERT ON "{from_table_real}" FOR EACH ROW EXECUTE PROCEDURE {trigger_name}();
                     "#,
-                    assignments = from_table_assignments.join("\n"),
+                    changed_table = table.name,
                     changed_table_real = table.real_name,
+                    changed_table_subquery = common::table_with_current_columns(&table),
                     from_table = from_table.name,
                     from_table_real = from_table.real_name,
+                    from_table_row = common::new_row_with_current_columns(&from_table),
                     trigger_name = self.trigger_name(ctx),
-                    // declarations = from_table_declarations.join("\n"),
                     temp_column_name = temp_column_name,
                 );
                 db.run(&query).context("failed to create up trigger")?;
 
-                let from_table_columns = from_table
-                    .columns
-                    .iter()
-                    .map(|column| format!("{} as {}", column.real_name, column.name))
-                    .collect::<Vec<String>>()
-                    .join(", ");
-
-                let changed_table_assignments: Vec<String> = table
-                    .columns
-                    .iter()
-                    .map(|column| {
-                        format!(
-                            "{table}.{alias} := NEW.{real_name};",
-                            table = table.name,
-                            alias = column.name,
-                            real_name = column.real_name,
-                        )
-                    })
-                    .collect();
-
-                // Add triggers to fill in values as they are inserted/updated
+                // When the changed table is written in the old schema, fill in the new
+                // column from the matching row of the source table
                 let query = format!(
                     r#"
                     CREATE OR REPLACE FUNCTION {trigger_name}()
@@ -266,21 +241,21 @@ impl Action for AddColumn {
                     BEGIN
                         IF NOT reshape.is_new_schema() AND NOT current_setting('reshape.disable_triggers', TRUE) = 'TRUE' THEN
                             DECLARE
-                                {changed_table} migration_{existing_schema_name}.{changed_table}%ROWTYPE;
-                                __temp_row migration_{existing_schema_name}.{from_table}%ROWTYPE;
+                                {changed_table} record;
+                                __from_row record;
                             BEGIN
-                                {changed_table_assignments}
+                                SELECT {changed_table_row} INTO {changed_table};
 
-                                SELECT {from_table_columns}
-                                INTO __temp_row
-                                FROM migration_{existing_schema_name}.{from_table} {from_table}
+                                SELECT "{from_table}".*
+                                INTO __from_row
+                                FROM {from_table_subquery}
                                 WHERE {where};
 
                                 DECLARE
-                                    {from_table} migration_{existing_schema_name}.{from_table}%ROWTYPE;
+                                    {from_table} record;
                                 BEGIN
-                                    {from_table} = __temp_row;
-                                    NEW.{temp_column_name} = {value};
+                                    {from_table} := __from_row;
+                                    NEW."{temp_column_name}" = {value};
                                 END;
                             END;
                         END IF;
@@ -291,13 +266,13 @@ impl Action for AddColumn {
                     DROP TRIGGER IF EXISTS "{trigger_name}" ON "{changed_table_real}";
                     CREATE TRIGGER "{trigger_name}" BEFORE UPDATE OR INSERT ON "{changed_table_real}" FOR EACH ROW EXECUTE PROCEDURE {trigger_name}();
                     "#,
-                    changed_table_assignments = changed_table_assignments.join("\n"),
-                    changed_table_real = table.real_name,
                     changed_table = table.name,
+                    changed_table_real = table.real_name,
+                    changed_table_row = common::new_row_with_current_columns(&table),
                     from_table = from_table.name,
+                    from_table_subquery = common::table_with_current_columns(&from_table),
                     trigger_name = self.reverse_trigger_name(ctx),
                     temp_column_name = temp_column_name,
-                    // declarations = declarations.join("\n"),
                 );
                 db.run(&query)
                     .context("failed to create reverse up trigger")?;

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use postgres::types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 
-use crate::db::Conn;
+use crate::{db::Conn, schema::Table};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Column {
@@ -322,4 +322,36 @@ pub fn get_index_definition(db: &mut dyn Conn, index_oid: u32) -> anyhow::Result
     .first()
     .map(|row| row.get("definition"))
     .ok_or_else(|| anyhow!("failed to get definition of index {}", index_oid))
+}
+
+// The row being written by a trigger with the columns under their current names, for
+// use as `SELECT {selection} INTO record`. Together with `table_with_current_columns`
+// this lets user-provided SQL reference both tables of a cross-table transformation by
+// the names they have in this migration, even when the real columns differ.
+pub fn new_row_with_current_columns(table: &Table) -> String {
+    table
+        .columns
+        .iter()
+        .map(|column| format!("NEW.\"{}\" AS \"{}\"", column.real_name, column.name))
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+// The real table exposed with its columns under their current names, aliased to the
+// table's current name, for use in a FROM clause. Includes the ctid so that matched
+// rows can be updated.
+pub fn table_with_current_columns(table: &Table) -> String {
+    let columns = table
+        .columns
+        .iter()
+        .map(|column| format!("\"{}\" AS \"{}\"", column.real_name, column.name))
+        .collect::<Vec<String>>()
+        .join(", ");
+
+    format!(
+        "(SELECT ctid, {columns} FROM public.\"{real_name}\") \"{name}\"",
+        columns = columns,
+        real_name = table.real_name,
+        name = table.name,
+    )
 }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -432,19 +432,13 @@ impl Clone for Migration {
 pub struct MigrationContext {
     migration_index: usize,
     action_index: usize,
-    existing_schema_name: Option<String>,
 }
 
 impl MigrationContext {
-    pub fn new(
-        migration_index: usize,
-        action_index: usize,
-        existing_schema_name: Option<String>,
-    ) -> Self {
+    pub fn new(migration_index: usize, action_index: usize) -> Self {
         MigrationContext {
             migration_index,
             action_index,
-            existing_schema_name,
         }
     }
 

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{Conn, Transaction},
     schema::Schema,
 };
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, Context};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -132,11 +132,6 @@ impl Action for RemoveColumn {
                 r#where,
             } = down
             {
-                let existing_schema_name = match &ctx.existing_schema_name {
-                    Some(name) => name,
-                    None => bail!("can't use update without previous migration"),
-                };
-
                 let from_table = schema.get_table(db, from_table)?;
 
                 let maybe_null_check = if !column.nullable {
@@ -196,19 +191,11 @@ impl Action for RemoveColumn {
                     "".to_string()
                 };
 
-                let into_variables = from_table
-                    .columns
-                    .iter()
-                    .map(|column| {
-                        format!(
-                            "NEW.{real_name} AS {alias}",
-                            alias = column.name,
-                            real_name = column.real_name,
-                        )
-                    })
-                    .collect::<Vec<String>>()
-                    .join(", ");
+                // Both tables are exposed with their columns under their current names, so
+                // `value` and `where` reference the schema as it looks in this migration.
 
+                // When the source table is written in the new schema, update the removed
+                // column of the matching rows
                 let query = format!(
                     r#"
                     CREATE OR REPLACE FUNCTION {trigger_name}()
@@ -219,17 +206,21 @@ impl Action for RemoveColumn {
                             DECLARE
                                 {from_table} record;
                             BEGIN
-                                SELECT {into_variables}
-                                INTO {from_table};
+                                SELECT {from_table_row} INTO {from_table};
 
                                 {maybe_null_check}
 
                                 -- Don't trigger reverse trigger when making this update
                                 perform set_config('reshape.disable_triggers', 'TRUE', TRUE);
 
-                                UPDATE "migration_{existing_schema_name}"."{changed_table}" "{changed_table}"
-                                SET "{column_name}" = {value}
-                                WHERE {where};
+                                UPDATE public."{changed_table_real}" AS __target
+                                SET "{column_name_real}" = __values.value
+                                FROM (
+                                    SELECT "{changed_table}".ctid, ({value}) AS value
+                                    FROM {changed_table_subquery}
+                                    WHERE {where}
+                                ) __values
+                                WHERE __target.ctid = __values.ctid;
 
                                 perform set_config('reshape.disable_triggers', '', TRUE);
                             END;
@@ -241,34 +232,19 @@ impl Action for RemoveColumn {
                     DROP TRIGGER IF EXISTS "{trigger_name}" ON "{from_table_real}";
                     CREATE TRIGGER "{trigger_name}" BEFORE UPDATE OR INSERT ON "{from_table_real}" FOR EACH ROW EXECUTE PROCEDURE {trigger_name}();
                     "#,
-                    changed_table = self.table,
+                    changed_table = table.name,
+                    changed_table_real = table.real_name,
+                    changed_table_subquery = common::table_with_current_columns(&table),
+                    column_name_real = column.real_name,
                     from_table = from_table.name,
                     from_table_real = from_table.real_name,
-                    column_name = self.column,
+                    from_table_row = common::new_row_with_current_columns(&from_table),
                     trigger_name = self.trigger_name(ctx),
                 );
                 db.run(&query).context("failed to create down trigger")?;
 
-                let changed_into_variables = table
-                    .columns
-                    .iter()
-                    .map(|column| {
-                        format!(
-                            "NEW.{real_name} AS {alias}",
-                            alias = column.name,
-                            real_name = column.real_name,
-                        )
-                    })
-                    .collect::<Vec<String>>()
-                    .join(", ");
-
-                let from_table_columns = from_table
-                    .columns
-                    .iter()
-                    .map(|column| format!("{} as {}", column.real_name, column.name))
-                    .collect::<Vec<String>>()
-                    .join(", ");
-
+                // When the changed table is written in the new schema, fill in the removed
+                // column from the matching row of the source table
                 let query = format!(
                     r#"
                     CREATE OR REPLACE FUNCTION {trigger_name}()
@@ -278,24 +254,20 @@ impl Action for RemoveColumn {
                         IF reshape.is_new_schema() AND NOT current_setting('reshape.disable_triggers', TRUE) = 'TRUE' THEN
                             DECLARE
                                 {changed_table} record;
-                                __temp_row record;
+                                __from_row record;
                             BEGIN
-                                SELECT {changed_into_variables}
-                                INTO {changed_table};
+                                SELECT {changed_table_row} INTO {changed_table};
 
-                                SELECT *
-                                INTO __temp_row
-                                FROM (
-                                    SELECT {from_table_columns}
-                                    FROM public.{from_table_real}
-                                ) {from_table}
+                                SELECT "{from_table}".*
+                                INTO __from_row
+                                FROM {from_table_subquery}
                                 WHERE {where};
 
                                 DECLARE
                                     {from_table} record;
                                 BEGIN
-                                    {from_table} := __temp_row;
-                                    NEW.{column_name_real} = {value};
+                                    {from_table} := __from_row;
+                                    NEW."{column_name_real}" = {value};
                                 END;
                             END;
                         END IF;
@@ -308,11 +280,11 @@ impl Action for RemoveColumn {
                     "#,
                     changed_table = table.name,
                     changed_table_real = table.real_name,
-                    from_table = from_table.name,
-                    from_table_real = from_table.real_name,
+                    changed_table_row = common::new_row_with_current_columns(&table),
                     column_name_real = column.real_name,
+                    from_table = from_table.name,
+                    from_table_subquery = common::table_with_current_columns(&from_table),
                     trigger_name = self.reverse_trigger_name(ctx),
-                    // declarations = declarations.join("\n"),
                 );
                 db.run(&query)
                     .context("failed to create reverse down trigger")?;

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -191,9 +191,6 @@ impl Action for RemoveColumn {
                     "".to_string()
                 };
 
-                // Both tables are exposed with their columns under their current names, so
-                // `value` and `where` reference the schema as it looks in this migration.
-
                 // When the source table is written in the new schema, update the removed
                 // column of the matching rows
                 let query = format!(

--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -640,6 +640,295 @@ fn add_column_with_default() {
 }
 
 #[test]
+fn add_column_complex_up_with_renamed_source_column() {
+    let mut test = Test::new("Cross-table up with renamed source column");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "rename_email_and_add_profile_email"
+
+        # `email` is renamed and replaced by a temporary column, and referenced by its new
+        # name from the cross-table transformation
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "email"
+        up = "email"
+        down = "email"
+
+            [actions.changes]
+            name = "mail"
+            type = "VARCHAR(255)"
+
+        [[actions]]
+        type = "add_column"
+        table = "profiles"
+
+            [actions.column]
+            name = "email"
+            type = "TEXT"
+
+            [actions.up]
+            table = "users"
+            value = "users.mail"
+            where = "profiles.user_id = users.id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query(
+            "
+            INSERT INTO users (id, email) VALUES (1, 'a@example.com');
+            INSERT INTO profiles (id, user_id) VALUES (10, 1);
+            ",
+        )
+        .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // Existing rows are backfilled
+        let email: Option<String> = new_db
+            .query_one("SELECT email FROM profiles WHERE id = 10", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!(Some("a@example.com".to_string()), email);
+
+        // A profile written in the old schema gets its email from the user
+        old_db
+            .simple_query("INSERT INTO users (id, email) VALUES (2, 'b@example.com')")
+            .unwrap();
+        old_db
+            .simple_query("INSERT INTO profiles (id, user_id) VALUES (20, 2)")
+            .unwrap();
+        let email: Option<String> = new_db
+            .query_one("SELECT email FROM profiles WHERE id = 20", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!(Some("b@example.com".to_string()), email);
+
+        // A user updated in the old schema updates the profile
+        old_db
+            .simple_query("UPDATE users SET email = 'c@example.com' WHERE id = 2")
+            .unwrap();
+        let email: Option<String> = new_db
+            .query_one("SELECT email FROM profiles WHERE id = 20", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!(Some("c@example.com".to_string()), email);
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_column_complex_up_with_renamed_target_column() {
+    let mut test = Test::new("Cross-table up with renamed target column");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "rename_user_id_and_add_profile_email"
+
+        # `user_id` is renamed and replaced by a temporary column on the table being
+        # changed, and referenced by its new name from the cross-table transformation
+        [[actions]]
+        type = "alter_column"
+        table = "profiles"
+        column = "user_id"
+        up = "user_id"
+        down = "user_id"
+
+            [actions.changes]
+            name = "owner_id"
+            type = "BIGINT"
+
+        [[actions]]
+        type = "add_column"
+        table = "profiles"
+
+            [actions.column]
+            name = "email"
+            type = "TEXT"
+
+            [actions.up]
+            table = "users"
+            value = "users.email"
+            where = "profiles.owner_id = users.id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query(
+            "
+            INSERT INTO users (id, email) VALUES (1, 'a@example.com');
+            INSERT INTO profiles (id, user_id) VALUES (10, 1);
+            ",
+        )
+        .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // Existing rows are backfilled
+        let email: Option<String> = new_db
+            .query_one("SELECT email FROM profiles WHERE id = 10", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!(Some("a@example.com".to_string()), email);
+
+        // A profile written in the old schema gets its email from the user
+        old_db
+            .simple_query("INSERT INTO users (id, email) VALUES (2, 'b@example.com')")
+            .unwrap();
+        old_db
+            .simple_query("INSERT INTO profiles (id, user_id) VALUES (20, 2)")
+            .unwrap();
+        let email: Option<String> = new_db
+            .query_one("SELECT email FROM profiles WHERE id = 20", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!(Some("b@example.com".to_string()), email);
+
+        // A user updated in the old schema updates the profile
+        old_db
+            .simple_query("UPDATE users SET email = 'c@example.com' WHERE id = 2")
+            .unwrap();
+        let email: Option<String> = new_db
+            .query_one("SELECT email FROM profiles WHERE id = 20", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!(Some("c@example.com".to_string()), email);
+    });
+
+    test.run();
+}
+
+#[test]
+fn add_column_complex_up_in_first_migration() {
+    let mut test = Test::new("Cross-table up without a previous migration");
+
+    // The tables are created in the same migration, so there is no previous schema to
+    // read the source table through
+    test.first_migration(
+        r#"
+        name = "create_tables_and_add_profile_email"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+        [[actions]]
+        type = "add_column"
+        table = "profiles"
+
+            [actions.column]
+            name = "email"
+            type = "TEXT"
+
+            [actions.up]
+            table = "users"
+            value = "users.email"
+            where = "profiles.user_id = users.id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, email) VALUES (1, 'a@example.com')")
+            .unwrap();
+        db.simple_query(
+            "INSERT INTO profiles (id, user_id, email) VALUES (10, 1, 'a@example.com')",
+        )
+        .unwrap();
+    });
+
+    test.run();
+}
+
+#[test]
 fn add_column_with_complex_up() {
     let mut test = Test::new("Add column complex");
 

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -129,6 +129,115 @@ fn remove_column_down_references_removed_column() {
 }
 
 #[test]
+fn remove_column_complex_down_with_renamed_source_column() {
+    let mut test = Test::new("Cross-table down with renamed source column");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    // `user_id` is renamed and replaced by a temporary column, and referenced by its new
+    // name from the cross-table transformation
+    test.second_migration(
+        r#"
+        name = "rename_user_id_and_remove_user_email"
+
+        [[actions]]
+        type = "alter_column"
+        table = "profiles"
+        column = "user_id"
+        up = "user_id"
+        down = "user_id"
+
+            [actions.changes]
+            name = "owner_id"
+            type = "BIGINT"
+
+        [[actions]]
+        type = "remove_column"
+        table = "users"
+        column = "email"
+
+            [actions.down]
+            table = "profiles"
+            value = "profiles.email"
+            where = "users.id = profiles.owner_id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query(
+            "
+            INSERT INTO users (id, email) VALUES (1, 'a@example.com');
+            INSERT INTO profiles (id, user_id, email) VALUES (10, 1, 'a@example.com');
+            ",
+        )
+        .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // A profile updated in the new schema writes the email back to the user
+        new_db
+            .simple_query("UPDATE profiles SET email = 'b@example.com' WHERE id = 10")
+            .unwrap();
+        let email: String = old_db
+            .query_one("SELECT email FROM users WHERE id = 1", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!("b@example.com", email);
+
+        // A user inserted in the new schema gets its email from the matching profile
+        new_db
+            .simple_query(
+                "INSERT INTO profiles (id, owner_id, email) VALUES (20, 2, 'c@example.com')",
+            )
+            .unwrap();
+        new_db
+            .simple_query("INSERT INTO users (id) VALUES (2)")
+            .unwrap();
+        let email: String = old_db
+            .query_one("SELECT email FROM users WHERE id = 2", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!("c@example.com", email);
+    });
+
+    test.run();
+}
+
+#[test]
 fn remove_column() {
     let mut test = Test::new("Remove column");
 


### PR DESCRIPTION
## Summary

The triggers generated for a cross-table `up` (`add_column`) or `down` (`remove_column`) resolved column names inconsistently: the other table was read through the previous migration's views, and the changed table was written through the real table by its real column names. Columns renamed or replaced earlier in the same migration were therefore invisible to `value` and `where`. A new name failed outright, and a column replaced by a temporary one silently read the old column, which after a transforming `up` holds different values. Cross-table transformations also required a previous migration to exist.

## Fix

Both tables are now exposed with their columns under their current names, in both triggers:

- The table being written is a `record` built from `NEW` with each real column aliased to its current name.
- The other table is a subquery over the real table which aliases every column and is named after the table's current name. It includes the `ctid`, so the changed table is updated with `UPDATE ... FROM (subquery) WHERE ctid = ...` rather than by naming real columns directly.

`value` and `where` are then evaluated against the schema as it looks in this migration, with no SQL rewriting. The previous-schema views are no longer used, so `MigrationContext` loses `existing_schema_name` and cross-table transformations work in a first migration. `remove_column`'s reverse trigger already used the subquery technique; it now shares the two helpers in `common.rs` with the rest.

## Test plan

- [x] `add_column_complex_up_with_renamed_source_column`: source column renamed with a type change in the same migration, referenced by its new name; backfill, reverse trigger and forward trigger all verified
- [x] `add_column_complex_up_with_renamed_target_column`: same for a column of the table being changed
- [x] `add_column_complex_up_in_first_migration`: no previous migration required
- [x] `remove_column_complex_down_with_renamed_source_column`: both directions verified
- [x] Existing cross-table tests and the README scenarios in `complex.rs` pass unchanged
- [x] Full suite green, `cargo clippy -- -D warnings` clean