### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 keywords = ["postgres", "migrations"]
 edition = "2021"
 authors = ["Fabian Lindfors"]
-rust-version = "1.70"
+rust-version = "1.88"
 
 [dependencies]
 postgres = { version = "0.19.12", features = ["with-serde_json-1"] }
@@ -18,11 +18,11 @@ serde_json = "1.0"
 typetag = "0.2"
 anyhow = { version = "1.0", features = ["backtrace"] }
 clap = { version = "4.5", features = ["derive"] }
-toml = "0.8"
+toml = "1"
 version = "3.0.0"
 colored = "3"
-rand = "0.9"
-dotenv = "0.15.0"
+rand = "0.10"
+dotenvy = "0.15"
 lexical-sort = "0.3.1"
 pg_query = "6.2"
 native-tls = { version = "0.2", features = ["vendored"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ fn run(opts: Opts) -> anyhow::Result<()> {
 
 fn reshape_from_connection_options(opts: &ConnectionOptions) -> anyhow::Result<Reshape> {
     // Load environment variables from .env file if it exists
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     let url_env = std::env::var("DB_URL").ok();
     let url = url_env.as_ref().or(opts.url.as_ref());


### PR DESCRIPTION
## Summary

| Crate | Before | After | Notes |
|---|---|---|---|
| `toml` | 0.8 | 1 | No code changes needed, only `toml::from_str` is used |
| `rand` | 0.9 | 0.10 | No code changes needed, `rand::rng()` and the prelude are unchanged |
| `dotenv` | 0.15 | replaced by `dotenvy` 0.15 | `dotenv` has been unmaintained since 2019 (RUSTSEC-2021-0141). `dotenvy` is the maintained fork with the same API |
| `rust-version` | 1.70 | 1.88 | See below |

Everything else is already on its latest release within the declared requirements and moves with `cargo update`: `postgres` 0.19.14, `clap` 4.6, `serde` 1.0.229, `serde_json` 1.0.151, `typetag` 0.2.23, `anyhow` 1.0.104, `native-tls` 0.2.18, `postgres-native-tls` 0.5.3. `colored`, `lexical-sort`, `version` and `pg_query` are on their latest versions.

## On `rust-version`

`Cargo.lock` isn't committed, so every fresh build resolves dependencies to their latest compatible versions. That resolution already requires Rust 1.88 through transitive dependencies, and 1.85 through `clap` 4.6 directly, so the declared 1.70 has not been buildable for a while. CI uses `stable` and the Docker image uses 1.93, so nothing enforced it. The new value reflects what the tree needs today.

## Test plan

- [x] Full suite green with the bumped dependencies
- [x] `cargo clippy -- -D warnings` clean