### PR TITLE
Fix warnings and clippy lints in the test helpers

### DIFF
--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -240,7 +240,7 @@ fn add_column_nullable() {
             .unwrap();
         let name: Option<String> = new_db
             .query_one("SELECT name from users WHERE id = 3", &[])
-            .map(|row| (row.get("name")))
+            .map(|row| row.get("name"))
             .unwrap();
         assert_eq!(None, name);
 

--- a/tests/alter_column.rs
+++ b/tests/alter_column.rs
@@ -743,7 +743,7 @@ fn alter_column_multiple() {
             .unwrap()
             .iter()
             .map(|row| row.get("counter"))
-            .nth(0)
+            .next()
             .unwrap();
         assert_eq!(52, result);
 
@@ -756,7 +756,7 @@ fn alter_column_multiple() {
             .unwrap()
             .iter()
             .map(|row| row.get("counter"))
-            .nth(0)
+            .next()
             .unwrap();
         assert_eq!(48, result);
     });

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -6,6 +6,7 @@ use reshape::{
     Reshape,
 };
 
+#[allow(dead_code)]
 pub fn assert_invalid(toml: &str) {
     let migration: Migration = toml::from_str(toml).unwrap();
     let errors: Vec<_> = migration
@@ -256,7 +257,7 @@ impl Test<'_> {
 }
 
 fn print_heading(text: &str) {
-    let delimiter = std::iter::repeat("=").take(80).collect::<String>();
+    let delimiter = "=".repeat(80);
 
     println!();
     println!();
@@ -276,12 +277,14 @@ fn print_success() {
 
 fn add_spacer(text: &str, char: &str) -> String {
     const TARGET_WIDTH: usize = 80;
-    let num_of_chars = (TARGET_WIDTH - text.len() - 2) / 2;
-    let spacer = std::iter::repeat(char)
-        .take(num_of_chars)
-        .collect::<String>();
+    let num_of_chars = TARGET_WIDTH.saturating_sub(text.len() + 2) / 2;
+    let spacer = char.repeat(num_of_chars);
 
-    let extra = if text.len() % 2 == 0 { "" } else { char };
+    let extra = if text.len().is_multiple_of(2) {
+        ""
+    } else {
+        char
+    };
 
     format!("{spacer} {text} {spacer}{extra}", spacer = spacer)
 }


### PR DESCRIPTION
## Summary

Every test binary printed the same two compiler warnings: `assert_invalid` is unused in the binaries that don't call it, and one closure body had redundant parentheses. `cargo clippy --all-targets` also had a few lints in the same helpers. All of them are in test code.

- `assert_invalid` gets `#[allow(dead_code)]` like the other shared helpers
- `std::iter::repeat(..).take(..).collect()` becomes `str::repeat`, `.nth(0)` becomes `.next()`, `% 2 == 0` becomes `is_multiple_of`
- The heading printer now uses a saturating subtraction, so a test title longer than the banner width no longer panics with an integer underflow. That has bitten twice while writing tests.

`cargo build --all-targets` and `cargo clippy --all-targets -- -D warnings` are both clean after this.

## Test plan

- [x] No warnings on any target
- [x] `add_column`, `alter_column` and `create_table` suites green