### PR TITLE
Name NOT NULL constraints after the final column on Postgres 18

### DIFF
--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -379,6 +379,10 @@ impl Action for AddColumn {
             ))
             .context("failed to rename column to final name")?;
 
+        if !self.column.nullable {
+            common::rename_not_null_constraint(&mut transaction, &self.table, &self.column.name)?;
+        }
+
         Ok(Some(transaction))
     }
 

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -210,6 +210,7 @@ impl Action for AlterColumn {
                     new_name = new_name,
                 );
                 db.run(&query).context("failed to rename column")?;
+                common::rename_not_null_constraint(db, &self.table, new_name)?;
             }
             return Ok(None);
         }
@@ -331,6 +332,7 @@ impl Action for AlterColumn {
         );
         db.run(&query)
             .context("failed to rename temporary column")?;
+        common::rename_not_null_constraint(db, &self.table, column_name)?;
 
         // Remove triggers and procedures
         let query = format!(

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use postgres::types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 
@@ -322,6 +322,75 @@ pub fn get_index_definition(db: &mut dyn Conn, index_oid: u32) -> anyhow::Result
     .first()
     .map(|row| row.get("definition"))
     .ok_or_else(|| anyhow!("failed to get definition of index {}", index_oid))
+}
+
+// Renames the NOT NULL constraint on a column, if there is one, to the name Postgres
+// would have given it had the column been declared NOT NULL under its current name.
+//
+// Since Postgres 18, `SET NOT NULL` creates a catalogued constraint named after the
+// column at the time. Reshape sets columns NOT NULL while they still have their temporary
+// names and renames them afterwards, which would otherwise leave the constraint named
+// after the temporary column. Earlier versions don't catalogue NOT NULL constraints, in
+// which case this does nothing.
+pub fn rename_not_null_constraint(
+    db: &mut dyn Conn,
+    table: &str,
+    column: &str,
+) -> anyhow::Result<()> {
+    let target_name = format!("{table}_{column}_not_null");
+
+    let current_name: Option<String> = db
+        .query_with_params(
+            "
+            SELECT c.conname AS name
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+            WHERE
+                c.contype = 'n' AND
+                t.relname = $1 AND
+                a.attname = $2
+            ",
+            &[&table, &column],
+        )
+        .context("failed to get NOT NULL constraint")?
+        .first()
+        .map(|row| row.get("name"));
+
+    let Some(current_name) = current_name else {
+        return Ok(());
+    };
+    if current_name == target_name {
+        return Ok(());
+    }
+
+    // Leave the constraint alone if the name is already taken, as the constraint's
+    // name is cosmetic and shouldn't stop a migration from completing
+    let target_name_taken = !db
+        .query_with_params(
+            "
+            SELECT 1
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            WHERE t.relname = $1 AND c.conname = $2
+            ",
+            &[&table, &target_name],
+        )
+        .context("failed to check for existing constraint")?
+        .is_empty();
+    if target_name_taken {
+        return Ok(());
+    }
+
+    db.run(&format!(
+        r#"
+        ALTER TABLE "{table}"
+        RENAME CONSTRAINT "{current_name}" TO "{target_name}"
+        "#,
+    ))
+    .context("failed to rename NOT NULL constraint")?;
+
+    Ok(())
 }
 
 // The row being written by a trigger with the columns under their current names, for

--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -166,6 +166,9 @@ fn add_column() {
             .iter()
             .map(|row| (row.get("first"), row.get("last")))
             .eq(expected));
+
+        common::assert_not_null_constraint_name(db, "users", "first");
+        common::assert_not_null_constraint_name(db, "users", "last");
     });
 
     test.after_abort(|db| {

--- a/tests/alter_column.rs
+++ b/tests/alter_column.rs
@@ -509,6 +509,8 @@ fn alter_column_set_not_null() {
         // Ensure NULL can't be inserted
         let result = db.simple_query("INSERT INTO users (id, name) VALUES (5, NULL)");
         assert!(result.is_err(), "expected insert to fail");
+
+        common::assert_not_null_constraint_name(db, "users", "name");
     });
 
     test.after_abort(|db| {
@@ -624,6 +626,7 @@ fn alter_column_rename() {
             [[actions.columns]]
             name = "name"
             type = "TEXT"
+            nullable = false
         "#,
     );
 
@@ -662,6 +665,10 @@ fn alter_column_rename() {
             .iter()
             .map(|row| row.get::<_, String>("full_name"))
             .eq(expected));
+    });
+
+    test.after_completion(|db| {
+        common::assert_not_null_constraint_name(db, "users", "full_name");
     });
 
     test.run();
@@ -1126,6 +1133,8 @@ fn alter_column_rename_and_change_type() {
             .unwrap();
         assert_eq!("balance_amount", name);
         assert_eq!("numeric", data_type);
+
+        common::assert_not_null_constraint_name(db, "accounts", "balance_amount");
     });
 
     test.after_abort(|db| {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -45,6 +45,33 @@ pub fn get_column_comment(db: &mut Client, relation: &str, column: &str) -> Opti
     .and_then(|row| row.get("comment"))
 }
 
+// Asserts that a NOT NULL column's constraint, if the Postgres version catalogues them
+// (18+), is named after the column's final name rather than a temporary one
+#[allow(dead_code)]
+pub fn assert_not_null_constraint_name(db: &mut Client, table: &str, column: &str) {
+    let names: Vec<String> = db
+        .query(
+            "
+            SELECT c.conname AS name
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+            WHERE c.contype = 'n' AND t.relname = $1 AND a.attname = $2
+            ",
+            &[&table, &column],
+        )
+        .unwrap()
+        .iter()
+        .map(|row| row.get("name"))
+        .collect();
+
+    let expected = format!("{table}_{column}_not_null");
+    assert!(
+        names.iter().all(|name| name == &expected),
+        "expected NOT NULL constraint on {table}.{column} to be named {expected}, found {names:?}"
+    );
+}
+
 pub struct Test<'a> {
     name: &'a str,
     reshape: Reshape,


### PR DESCRIPTION
## Summary
- Since Postgres 18, `SET NOT NULL` creates a catalogued constraint named after the column at that moment. `add_column` and `alter_column` set the temporary column NOT NULL and rename it afterwards, which left the constraint named after the temporary column (e.g. `users___reshape_0000_0000_temp_column_users_first_not_null`).
- Adds `common::rename_not_null_constraint`, which after a column rename renames the column's NOT NULL constraint to the name Postgres would have generated (`{table}_{column}_not_null`). On Postgres 12 to 17 there is no such constraint, so it does nothing. If the target name is already taken it leaves the constraint alone rather than failing the completion.
- `add_column` calls it inside the completion transaction. `alter_column` calls it after both of its renames, including the rename-only short-circuit path where a renamed NOT NULL column kept a constraint named after the old column.

## Test plan
- New assertions on the final constraint name in `add_column`, `alter_column_set_not_null`, `alter_column_rename` and `alter_column_rename_and_change_type`. All three affected tests fail without the fix against Postgres 18.3.
- Full suite passes with `--test-threads=1` on Postgres 18.3.
- `cargo clippy -- -D warnings` is clean.