### PR TITLE
Keep check constraints when altering a column

### DIFF
--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -1,5 +1,5 @@
 use super::{Action, MigrationContext, NameField, References, SqlField, TableScope};
-use crate::sql::rewrite_index_definition;
+use crate::sql::{rewrite_column_references, rewrite_index_definition};
 use crate::{
     db::{Conn, Transaction},
     migrations::common,
@@ -171,6 +171,54 @@ impl Action for AlterColumn {
                 .context("failed to create temporary index")?;
         }
 
+        // Duplicate any check constraints which reference the column onto the temporary
+        // column, rewriting the expression so the column is replaced by the temporary one.
+        // Dropping the old column on completion also drops every check constraint involving
+        // it, so these copies are what remain afterwards. Each copy is validated right away
+        // so that an `up` transformation which breaks a check fails the migration while it
+        // can still be aborted.
+        let checks =
+            common::get_check_constraints_for_column(db, &table.real_name, &column.real_name)?;
+        for check in checks
+            .into_iter()
+            .filter(|check| !common::is_temporary_not_null_constraint(&check.name))
+        {
+            let temp_check_name = self.temp_check_name(ctx, check.oid);
+
+            if !common::check_constraint_exists(db, &table.real_name, &temp_check_name)? {
+                let expression = rewrite_column_references(&check.expression, &index_table)
+                    .with_context(|| {
+                        format!(
+                            "failed to rewrite definition of check constraint {}",
+                            check.name
+                        )
+                    })?;
+
+                db.run(&format!(
+                    r#"
+                    ALTER TABLE "{table}"
+                    ADD CONSTRAINT "{constraint_name}"
+                    CHECK ({expression}) NOT VALID
+                    "#,
+                    table = table.real_name,
+                    constraint_name = temp_check_name,
+                    expression = expression,
+                ))
+                .with_context(|| format!("failed to copy check constraint {}", check.name))?;
+            }
+
+            // Validating scans the table but doesn't block reads or writes
+            db.run(&format!(
+                r#"
+                ALTER TABLE "{table}"
+                VALIDATE CONSTRAINT "{constraint_name}"
+                "#,
+                table = table.real_name,
+                constraint_name = temp_check_name,
+            ))
+            .with_context(|| format!("failed to validate check constraint {}", check.name))?;
+        }
+
         // Add a temporary NOT NULL constraint if the column shouldn't be nullable.
         // This constraint is set as NOT VALID so it doesn't apply to existing rows and
         // the existing rows don't need to be scanned under an exclusive lock.
@@ -309,6 +357,39 @@ impl Action for AlterColumn {
             .context("failed to drop old index")?;
         }
 
+        // Replace the check constraints which reference the old column with the copies
+        // made for the temporary column. The originals would be dropped together with the
+        // old column anyway, and the copies take over their names. Copies which don't
+        // exist belong to another action altering a column in the same migration.
+        let checks = common::get_check_constraints_for_column(db, &self.table, &self.column)?;
+        for check in checks {
+            let temp_check_name = self.temp_check_name(ctx, check.oid);
+            if !common::check_constraint_exists(db, &self.table, &temp_check_name)? {
+                continue;
+            }
+
+            db.run(&format!(
+                r#"
+                ALTER TABLE "{table}"
+                DROP CONSTRAINT IF EXISTS "{constraint_name}"
+                "#,
+                table = self.table,
+                constraint_name = check.name,
+            ))
+            .with_context(|| format!("failed to drop check constraint {}", check.name))?;
+
+            db.run(&format!(
+                r#"
+                ALTER TABLE "{table}"
+                RENAME CONSTRAINT "{temp_check_name}" TO "{constraint_name}"
+                "#,
+                table = self.table,
+                temp_check_name = temp_check_name,
+                constraint_name = check.name,
+            ))
+            .with_context(|| format!("failed to rename check constraint {}", check.name))?;
+        }
+
         // Remove old column
         let query = format!(
             r#"
@@ -394,6 +475,20 @@ impl Action for AlterColumn {
             ))?;
         }
 
+        // Remove any check constraints copied onto the temporary column
+        let checks = common::get_check_constraints_for_column(db, &self.table, &temp_column_name)?;
+        for check in checks {
+            db.run(&format!(
+                r#"
+                ALTER TABLE "{table}"
+                DROP CONSTRAINT IF EXISTS "{constraint_name}"
+                "#,
+                table = self.table,
+                constraint_name = check.name,
+            ))
+            .with_context(|| format!("failed to drop check constraint {}", check.name))?;
+        }
+
         // Drop temporary column
         let query = format!(
             r#"
@@ -477,6 +572,14 @@ impl AlterColumn {
 
     fn temp_index_name(&self, ctx: &MigrationContext, index_oid: u32) -> String {
         format!("{}_alter_column_temp_index_{}", ctx.prefix(), index_oid)
+    }
+
+    fn temp_check_name(&self, ctx: &MigrationContext, constraint_oid: u32) -> String {
+        format!(
+            "{}_alter_column_temp_check_{}",
+            ctx.prefix(),
+            constraint_oid
+        )
     }
 
     fn can_short_circuit(&self) -> bool {

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -314,6 +314,87 @@ pub fn get_indices_for_column(
     Ok(indices)
 }
 
+pub struct CheckConstraint {
+    pub name: String,
+    pub oid: u32,
+    pub expression: String,
+}
+
+// Finds all CHECK constraints which reference a column, including ones which span
+// several columns. The expression is returned without the surrounding CHECK ( ... ).
+pub fn get_check_constraints_for_column(
+    db: &mut dyn Conn,
+    table: &str,
+    column: &str,
+) -> anyhow::Result<Vec<CheckConstraint>> {
+    let constraints = db
+        .query(&format!(
+            "
+            SELECT
+                c.conname AS name,
+                c.oid AS oid,
+                pg_get_expr(c.conbin, c.conrelid) AS expression
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            JOIN pg_attribute a ON
+                a.attrelid = t.oid AND
+                a.attname = '{column}'
+            WHERE
+                c.contype = 'c' AND
+                n.nspname = 'public' AND
+                t.relname = '{table}' AND
+                a.attnum = ANY(c.conkey)
+            ORDER BY c.conname
+            ",
+            table = table,
+            column = column,
+        ))?
+        .iter()
+        .map(|row| CheckConstraint {
+            name: row.get("name"),
+            oid: row.get("oid"),
+            expression: row.get("expression"),
+        })
+        .collect();
+
+    Ok(constraints)
+}
+
+// Whether a constraint is one of the temporary NOT NULL checks which `add_column` and
+// `alter_column` add to a new column. These are replaced by a real NOT NULL on
+// completion and are not constraints which should be preserved.
+pub fn is_temporary_not_null_constraint(name: &str) -> bool {
+    name.starts_with("__reshape_")
+        && (name.ends_with("_alter_column_temporary") || name.contains("_add_column_not_null_"))
+}
+
+pub fn check_constraint_exists(
+    db: &mut dyn Conn,
+    table: &str,
+    constraint: &str,
+) -> anyhow::Result<bool> {
+    let exists = !db
+        .query(&format!(
+            "
+            SELECT 1
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            WHERE
+                c.contype = 'c' AND
+                n.nspname = 'public' AND
+                t.relname = '{table}' AND
+                c.conname = '{constraint}'
+            ",
+            table = table,
+            constraint = constraint,
+        ))?
+        .is_empty();
+
+    Ok(exists)
+}
+
 // The CREATE INDEX statement which defines an index
 pub fn get_index_definition(db: &mut dyn Conn, index_oid: u32) -> anyhow::Result<String> {
     db.query(&format!(

--- a/tests/alter_column.rs
+++ b/tests/alter_column.rs
@@ -326,6 +326,237 @@ fn alter_column_keeps_indexes_referencing_column() {
     test.run();
 }
 
+#[test]
+fn alter_column_keeps_check_constraints_referencing_column() {
+    let mut test = Test::new("Alter column keeps check constraints referencing it");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "score"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "max_score"
+            type = "INTEGER"
+
+            # One check on the column alone and one spanning another column. Both must
+            # survive the column being replaced.
+            [[actions.checks]]
+            name = "users_score_positive"
+            expression = "score >= 0"
+
+            [[actions.checks]]
+            name = "users_score_within_max"
+            expression = "score <= max_score"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, score, max_score) VALUES (1, 5, 10)")
+            .unwrap();
+    });
+
+    test.second_migration(
+        r#"
+        name = "alter_score"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "score"
+        up = "score"
+        down = "score"
+
+            [actions.changes]
+            name = "points"
+            type = "BIGINT"
+        "#,
+    );
+
+    test.intermediate(|old_db, new_db| {
+        // Each check has been copied onto the temporary column and validated
+        let temp_definitions = check_definitions(old_db, "__reshape%");
+        assert_eq!(2, temp_definitions.len(), "got: {:?}", temp_definitions);
+        for definition in &temp_definitions {
+            assert!(
+                definition.contains("__reshape"),
+                "expected temporary check to reference temporary column, got: {}",
+                definition
+            );
+        }
+        assert!(
+            check_validity(old_db, "__reshape%")
+                .iter()
+                .all(|valid| *valid),
+            "expected temporary checks to be validated"
+        );
+
+        // The original checks are untouched
+        assert_eq!(2, check_definitions(old_db, "users_score_%").len());
+
+        // Both schemas still reject invalid rows
+        assert!(old_db
+            .simple_query("INSERT INTO users (id, score, max_score) VALUES (2, -1, 10)")
+            .is_err());
+        assert!(new_db
+            .simple_query("INSERT INTO users (id, points, max_score) VALUES (2, 11, 10)")
+            .is_err());
+        new_db
+            .simple_query("INSERT INTO users (id, points, max_score) VALUES (2, 10, 10)")
+            .unwrap();
+    });
+
+    test.after_completion(|db| {
+        // The checks remain under their original names, now on the new column
+        let definitions = check_definitions(db, "users_score_%");
+        assert_eq!(2, definitions.len(), "got: {:?}", definitions);
+        for definition in &definitions {
+            assert!(
+                definition.contains("points") && !definition.contains("__reshape"),
+                "expected check to reference the final column, got: {}",
+                definition
+            );
+        }
+        assert!(check_definitions(db, "__reshape%").is_empty());
+
+        assert!(db
+            .simple_query("INSERT INTO users (id, points, max_score) VALUES (3, -1, 10)")
+            .is_err());
+        assert!(db
+            .simple_query("INSERT INTO users (id, points, max_score) VALUES (3, 11, 10)")
+            .is_err());
+        db.simple_query("INSERT INTO users (id, points, max_score) VALUES (3, 10, 10)")
+            .unwrap();
+    });
+
+    test.after_abort(|db| {
+        let definitions = check_definitions(db, "users_score_%");
+        assert_eq!(2, definitions.len(), "got: {:?}", definitions);
+        for definition in &definitions {
+            assert!(
+                definition.contains("score") && !definition.contains("__reshape"),
+                "expected check to reference the original column, got: {}",
+                definition
+            );
+        }
+        assert!(check_definitions(db, "__reshape%").is_empty());
+
+        assert!(db
+            .simple_query("INSERT INTO users (id, score, max_score) VALUES (3, -1, 10)")
+            .is_err());
+    });
+
+    test.run();
+}
+
+#[test]
+fn alter_column_fails_when_up_breaks_check_constraint() {
+    let mut test = Test::new("Alter column fails when up breaks a check constraint");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "score"
+            type = "INTEGER"
+
+            [[actions.checks]]
+            name = "users_score_positive"
+            expression = "score >= 0"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, score) VALUES (1, 5)")
+            .unwrap();
+    });
+
+    // The transformed values violate the existing check, which must fail the migration
+    // rather than silently dropping the check on completion
+    test.second_migration(
+        r#"
+        name = "alter_score"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "score"
+        up = "score - 100"
+        down = "score + 100"
+
+            [actions.changes]
+            type = "BIGINT"
+        "#,
+    );
+
+    test.expect_failure();
+
+    test.after_abort(|db| {
+        assert_eq!(1, check_definitions(db, "users_score_%").len());
+        assert!(check_definitions(db, "__reshape%").is_empty());
+    });
+
+    test.run();
+}
+
+fn check_definitions(db: &mut postgres::Client, name_pattern: &str) -> Vec<String> {
+    db.query(
+        "
+        SELECT pg_get_constraintdef(c.oid) AS definition
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.contype = 'c' AND n.nspname = 'public' AND c.conname LIKE $1
+        ORDER BY c.conname
+        ",
+        &[&name_pattern],
+    )
+    .unwrap()
+    .iter()
+    .map(|row| row.get("definition"))
+    .collect()
+}
+
+fn check_validity(db: &mut postgres::Client, name_pattern: &str) -> Vec<bool> {
+    db.query(
+        "
+        SELECT c.convalidated AS valid
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.contype = 'c' AND n.nspname = 'public' AND c.conname LIKE $1
+        ORDER BY c.conname
+        ",
+        &[&name_pattern],
+    )
+    .unwrap()
+    .iter()
+    .map(|row| row.get("valid"))
+    .collect()
+}
+
 fn index_definitions(db: &mut postgres::Client, name_pattern: &str) -> Vec<String> {
     db.query(
         "

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -352,4 +352,26 @@ pub fn assert_cleaned_up(db: &mut Client) {
         "expected no functions to exist, found: {}",
         functions.join(", ")
     );
+
+    // Make sure no temporary constraints remain
+    let constraints: Vec<String> = db
+        .query(
+            "
+            SELECT constraint_name
+            FROM information_schema.table_constraints
+            WHERE table_schema = 'public'
+            AND constraint_name LIKE '__reshape%'
+            ",
+            &[],
+        )
+        .unwrap()
+        .iter()
+        .map(|row| row.get(0))
+        .collect();
+
+    assert!(
+        constraints.is_empty(),
+        "expected no temporary constraints to exist, found: {}",
+        constraints.join(", ")
+    );
 }


### PR DESCRIPTION
## Problem

Completing an `alter_column` drops the old column with `DROP COLUMN ... CASCADE`, and Postgres drops every check constraint involving a dropped column along with it. Any check referencing the altered column was silently lost, whether it covered only that column or spanned several. Indices were already carried over to the new column, but check constraints were not.

## Change

Check constraints are now carried over the same way indices are:

- **run**: each check referencing the column is copied onto the temporary column under a `__reshape_..._alter_column_temp_check_{oid}` name, with its expression rewritten via the existing `rewrite_column_references`. The copy is added `NOT VALID` and validated immediately, so an `up` transformation which breaks a check fails the migration while it can still be aborted, rather than surfacing at completion.
- **complete**: the original is dropped and the copy is renamed to the original name, before the old column is dropped.
- **abort**: the copies are dropped.

The temporary NOT NULL checks which `add_column` and `alter_column` use are skipped, since those are replaced by a real NOT NULL on completion. Without this, altering the same column twice in one migration left an orphaned copy behind.

Naming copies by the original constraint's OID means two `alter_column` actions on different columns sharing a multi-column check compose correctly, since a constraint keeps its OID across renames.

## Tests

- New test covering a single-column and a multi-column check through a combined type change and rename: copies exist and are validated during the migration, the originals survive under their names after completion and after abort, and violating rows are rejected at every stage.
- New test asserting that an `up` which violates an existing check fails the migration and leaves the check intact after abort.
- The test harness now asserts that no `__reshape` constraints remain after any test.
