### PR TITLE
Add add_check and remove_check actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Designed for Postgres 12 and later.
     - [Remove table](#remove-table)
     - [Add foreign key](#add-foreign-key)
     - [Remove foreign key](#remove-foreign-key)
+    - [Add check](#add-check)
+    - [Remove check](#remove-check)
   - [Columns](#columns)
     - [Add column](#add-column)
     - [Alter column](#alter-column)
@@ -357,6 +359,66 @@ _Example: remove foreign key `items_user_id_fkey` from `users` table_
 type = "remove_foreign_key"
 table = "items"
 foreign_key = "items_user_id_fkey"
+```
+
+#### Add check
+
+The `add_check` action will add a check constraint to an existing table. The migration will fail if any existing rows don't satisfy the check. Once added, the check is enforced for both the old and the new schema, so your existing application must already write rows which satisfy it.
+
+_Example: add check that `age` on `users` table is not negative_
+
+```toml
+[[actions]]
+type = "add_check"
+table = "users"
+
+	[actions.check]
+	name = "users_age_check"
+	expression = "age >= 0"
+```
+
+_Example: add check spanning multiple columns_
+
+```toml
+[[actions]]
+type = "add_check"
+table = "bookings"
+
+	[actions.check]
+	name = "bookings_period_check"
+	expression = "ends_at > starts_at"
+```
+
+#### Remove check
+
+The `remove_check` action will remove an existing check constraint. The check will only be removed once the migration is completed, which means that your new application must continue to adhere to the check.
+
+_Example: remove check `users_age_check` from `users` table_
+
+```toml
+[[actions]]
+type = "remove_check"
+table = "users"
+check = "users_age_check"
+```
+
+To replace a check, remove it and add a new one with the same name in the same migration. Both checks are enforced until the migration is completed.
+
+_Example: allow negative ages down to -10_
+
+```toml
+[[actions]]
+type = "remove_check"
+table = "users"
+check = "users_age_check"
+
+[[actions]]
+type = "add_check"
+table = "users"
+
+	[actions.check]
+	name = "users_age_check"
+	expression = "age >= -10"
 ```
 
 ### Columns

--- a/README.md
+++ b/README.md
@@ -404,23 +404,6 @@ check = "users_age_check"
 
 To replace a check, remove it and add a new one with the same name in the same migration. Both checks are enforced until the migration is completed.
 
-_Example: allow negative ages down to -10_
-
-```toml
-[[actions]]
-type = "remove_check"
-table = "users"
-check = "users_age_check"
-
-[[actions]]
-type = "add_check"
-table = "users"
-
-	[actions.check]
-	name = "users_age_check"
-	expression = "age >= -10"
-```
-
 ### Columns
 
 #### Add column

--- a/src/docs/actions/add-check.md
+++ b/src/docs/actions/add-check.md
@@ -70,9 +70,8 @@ table = "users"
 ## Behavior
 
 1. **Start phase**:
-   - Scans the table for rows which violate the check and fails, listing some of them, if any are found. This happens before the check exists, so a bad check never affects the application.
    - Creates the check with `NOT VALID` (doesn't lock for validation)
-   - Validates the constraint (scans table but doesn't block writes). If validation fails the check is dropped again before the error is reported.
+   - Validates the constraint (scans table but doesn't block writes). If existing rows violate the check, the check is dropped again and the migration fails with an error listing some of the rows.
 
 2. **Complete phase**:
    - Renames constraint to its final name
@@ -80,6 +79,6 @@ table = "users"
 ## Notes
 
 - The check is enforced immediately for new inserts and updates, from both the old and the new schema. Reshape assumes the existing application already writes rows which satisfy it.
-- The initial scan is a plain read which doesn't block the application. It exists to fail early; validation of the constraint is what guarantees every row satisfies the check.
+- Existing data is validated after creation, as for foreign keys
 - The check fails if a constraint with the same name already exists, unless the same migration removes it first.
 - A `NULL` result satisfies a check, following Postgres semantics.

--- a/src/docs/actions/add-check.md
+++ b/src/docs/actions/add-check.md
@@ -1,0 +1,85 @@
+# add_check
+
+Add a check constraint to a table.
+
+## Schema
+
+```toml
+[[actions]]
+type = "add_check"
+table = "table_name"          # Required: table to add the check to
+
+    [actions.check]           # Required: check definition
+    name = "constraint_name"  # Required: name of the constraint
+    expression = "col > 0"    # Required: SQL expression every row must satisfy
+```
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `table` | string | Yes | Table to add the check to |
+| `check.name` | string | Yes | Name of the constraint |
+| `check.expression` | string | Yes | SQL expression which every row must satisfy. May reference any column of the table by its current name. |
+
+## Examples
+
+### Check on a Single Column
+
+```toml
+[[actions]]
+type = "add_check"
+table = "users"
+
+    [actions.check]
+    name = "users_age_check"
+    expression = "age >= 0"
+```
+
+### Check Spanning Several Columns
+
+```toml
+[[actions]]
+type = "add_check"
+table = "bookings"
+
+    [actions.check]
+    name = "bookings_period_check"
+    expression = "ends_at > starts_at"
+```
+
+### Replacing an Existing Check
+
+A check is replaced by removing it and adding a new one with the same name in the same migration.
+
+```toml
+[[actions]]
+type = "remove_check"
+table = "users"
+check = "users_age_check"
+
+[[actions]]
+type = "add_check"
+table = "users"
+
+    [actions.check]
+    name = "users_age_check"
+    expression = "age >= -1"
+```
+
+## Behavior
+
+1. **Start phase**:
+   - Scans the table for rows which violate the check and fails, listing some of them, if any are found. This happens before the check exists, so a bad check never affects the application.
+   - Creates the check with `NOT VALID` (doesn't lock for validation)
+   - Validates the constraint (scans table but doesn't block writes). If validation fails the check is dropped again before the error is reported.
+
+2. **Complete phase**:
+   - Renames constraint to its final name
+
+## Notes
+
+- The check is enforced immediately for new inserts and updates, from both the old and the new schema. Reshape assumes the existing application already writes rows which satisfy it.
+- The initial scan is a plain read which doesn't block the application. It exists to fail early; validation of the constraint is what guarantees every row satisfies the check.
+- The check fails if a constraint with the same name already exists, unless the same migration removes it first.
+- A `NULL` result satisfies a check, following Postgres semantics.

--- a/src/docs/actions/add-check.md
+++ b/src/docs/actions/add-check.md
@@ -71,7 +71,7 @@ table = "users"
 
 1. **Start phase**:
    - Creates the check with `NOT VALID` (doesn't lock for validation)
-   - Validates the constraint (scans table but doesn't block writes). If existing rows violate the check, the check is dropped again and the migration fails with an error listing some of the rows.
+   - Validates the constraint (scans table but doesn't block writes). If existing rows violate the check, the check is dropped again and the migration fails.
 
 2. **Complete phase**:
    - Renames constraint to its final name

--- a/src/docs/actions/add-check.md
+++ b/src/docs/actions/add-check.md
@@ -7,11 +7,11 @@ Add a check constraint to a table.
 ```toml
 [[actions]]
 type = "add_check"
-table = "table_name"          # Required: table to add the check to
+table = "table_name"
 
-    [actions.check]           # Required: check definition
-    name = "constraint_name"  # Required: name of the constraint
-    expression = "col > 0"    # Required: SQL expression every row must satisfy
+    [actions.check]
+    name = "constraint_name"
+    expression = "col > 0"
 ```
 
 ## Fields
@@ -80,5 +80,3 @@ table = "users"
 
 - The check is enforced immediately for new inserts and updates, from both the old and the new schema. Reshape assumes the existing application already writes rows which satisfy it.
 - Existing data is validated after creation, as for foreign keys
-- The check fails if a constraint with the same name already exists, unless the same migration removes it first.
-- A `NULL` result satisfies a check, following Postgres semantics.

--- a/src/docs/actions/remove-check.md
+++ b/src/docs/actions/remove-check.md
@@ -1,0 +1,45 @@
+# remove_check
+
+Remove a check constraint from a table.
+
+## Schema
+
+```toml
+[[actions]]
+type = "remove_check"
+table = "table_name"          # Required: table with the check
+check = "constraint_name"     # Required: constraint name
+```
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `table` | string | Yes | Table containing the check |
+| `check` | string | Yes | Name of the constraint to remove |
+
+## Example
+
+```toml
+[[actions]]
+type = "remove_check"
+table = "users"
+check = "users_age_check"
+```
+
+## Behavior
+
+1. **Start phase**:
+   - Validates that the check exists
+   - Check remains enforced
+
+2. **Complete phase**:
+   - Drops the check constraint
+
+## Notes
+
+- The check remains enforced during the migration period, so the new application must keep writing rows which satisfy it until the migration is completed
+- This ensures data consistency for the old schema
+- The constraint is only removed during completion
+- To replace a check, remove it and add a new one with the same name in the same migration (see `add_check`)
+- Find constraint names using: `\d table_name` in psql

--- a/src/docs/actions/remove-check.md
+++ b/src/docs/actions/remove-check.md
@@ -42,4 +42,3 @@ check = "users_age_check"
 - This ensures data consistency for the old schema
 - The constraint is only removed during completion
 - To replace a check, remove it and add a new one with the same name in the same migration (see `add_check`)
-- Find constraint names using: `\d table_name` in psql

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -97,6 +97,8 @@ After having written new migrations, ALWAYS run `specific check` to ensure the m
 | -------------------- | ---------------------------- | ----------------------------- |
 | `add_foreign_key`    | Add a foreign key constraint | `/actions/add-foreign-key`    |
 | `remove_foreign_key` | Remove a foreign key         | `/actions/remove-foreign-key` |
+| `add_check`          | Add a check constraint       | `/actions/add-check`          |
+| `remove_check`       | Remove a check constraint    | `/actions/remove-check`       |
 
 ## Custom Operations
 

--- a/src/migrations/add_check.rs
+++ b/src/migrations/add_check.rs
@@ -1,0 +1,212 @@
+use super::{common, Action, MigrationContext, NameField, References, SqlField};
+use crate::{
+    db::{Conn, Transaction},
+    schema::Schema,
+    sql::rewrite_column_references,
+};
+use anyhow::{anyhow, Context};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AddCheck {
+    pub table: String,
+    check: CheckDefinition,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CheckDefinition {
+    pub name: String,
+    pub expression: String,
+}
+
+// The number of violating rows to include in an error
+const VIOLATION_EXAMPLES: usize = 5;
+
+#[typetag::serde(name = "add_check")]
+impl Action for AddCheck {
+    fn describe(&self) -> String {
+        format!(
+            "Adding check constraint \"{}\" to table \"{}\"",
+            self.check.name, self.table
+        )
+    }
+
+    fn run(
+        &self,
+        ctx: &MigrationContext,
+        db: &mut dyn Conn,
+        schema: &Schema,
+    ) -> anyhow::Result<()> {
+        let table = schema.get_table(db, &self.table)?;
+
+        // The final name must be free by the time the migration completes. A constraint
+        // with the same name may exist if the migration removes it, which makes it
+        // possible to replace a check by removing and adding it in the same migration.
+        if !schema.is_check_removed(&self.table, &self.check.name)
+            && common::check_constraint_exists(db, &table.real_name, &self.check.name)?
+        {
+            return Err(anyhow!(
+                "check constraint \"{}\" already exists on table \"{}\"",
+                self.check.name,
+                self.table
+            ));
+        }
+
+        // The expression references columns by their current names, which may be backed
+        // by differently named columns during the migration
+        let expression = rewrite_column_references(&self.check.expression, &table)
+            .context("failed to resolve columns referenced by check")?;
+
+        let temp_constraint_name = self.temp_constraint_name(ctx);
+
+        if !common::check_constraint_exists(db, &table.real_name, &temp_constraint_name)? {
+            // Look for existing rows which violate the check before adding it. Once added,
+            // the check is enforced on every write, including those of the old schema, so
+            // a check which the existing data doesn't satisfy should fail before that
+            // point. This is only an early exit: the scan doesn't block the application
+            // but rows written after it are only covered by the validation below.
+            let violations = common::find_check_violations(
+                db,
+                &table.real_name,
+                &expression,
+                VIOLATION_EXAMPLES,
+            )
+            .context("failed to check existing rows against check")?;
+            if !violations.is_empty() {
+                return Err(self.violation_error(&violations));
+            }
+
+            // Create the check but set it as NOT VALID. This means the check is enforced
+            // for inserts and updates but the existing data isn't checked, which would
+            // require a long-lived lock.
+            db.run(&format!(
+                r#"
+                ALTER TABLE "{table}"
+                ADD CONSTRAINT "{constraint_name}"
+                CHECK ({expression})
+                NOT VALID
+                "#,
+                table = table.real_name,
+                constraint_name = temp_constraint_name,
+                expression = expression,
+            ))
+            .context("failed to create check constraint")?;
+        }
+
+        // Validating scans the table but doesn't block reads or writes. Together with the
+        // NOT VALID constraint, which covers every row written since it was added, this
+        // proves that every row satisfies the check.
+        let validation = db.run(&format!(
+            r#"
+            ALTER TABLE "{table}"
+            VALIDATE CONSTRAINT "{constraint_name}"
+            "#,
+            table = table.real_name,
+            constraint_name = temp_constraint_name,
+        ));
+
+        if let Err(error) = validation {
+            // Drop the check right away so it doesn't stay enforced on the old schema
+            // until the migration is aborted
+            self.drop_temp_constraint(ctx, db, &table.real_name)?;
+
+            let violations = common::find_check_violations(
+                db,
+                &table.real_name,
+                &expression,
+                VIOLATION_EXAMPLES,
+            )
+            .unwrap_or_default();
+            return Err(error.context(self.violation_error(&violations)));
+        }
+
+        Ok(())
+    }
+
+    fn complete<'a>(
+        &self,
+        ctx: &MigrationContext,
+        db: &'a mut dyn Conn,
+    ) -> anyhow::Result<Option<Transaction<'a>>> {
+        let temp_constraint_name = self.temp_constraint_name(ctx);
+
+        // The constraint has already been renamed if completion is being retried
+        if common::check_constraint_exists(db, &self.table, &temp_constraint_name)? {
+            db.run(&format!(
+                r#"
+                ALTER TABLE "{table}"
+                RENAME CONSTRAINT "{temp_constraint_name}" TO "{constraint_name}"
+                "#,
+                table = self.table,
+                temp_constraint_name = temp_constraint_name,
+                constraint_name = self.check.name,
+            ))
+            .context("failed to rename temporary check constraint")?;
+        }
+
+        Ok(None)
+    }
+
+    fn update_schema(&self, _ctx: &MigrationContext, schema: &mut Schema) {
+        let check_name = self.check.name.clone();
+        schema.change_table(&self.table, |table_changes| {
+            table_changes.set_check_added(&check_name);
+        });
+    }
+
+    fn abort(&self, ctx: &MigrationContext, db: &mut dyn Conn) -> anyhow::Result<()> {
+        self.drop_temp_constraint(ctx, db, &self.table)
+    }
+
+    fn sql_fields(&self) -> Vec<SqlField> {
+        vec![SqlField::expression(
+            "check.expression",
+            &self.check.expression,
+            References::table(&self.table),
+        )]
+    }
+
+    fn name_fields(&self) -> Vec<NameField> {
+        vec![NameField::table("table", &self.table)]
+    }
+}
+
+impl AddCheck {
+    fn temp_constraint_name(&self, ctx: &MigrationContext) -> String {
+        format!("{}_temp_check", ctx.prefix())
+    }
+
+    fn drop_temp_constraint(
+        &self,
+        ctx: &MigrationContext,
+        db: &mut dyn Conn,
+        table: &str,
+    ) -> anyhow::Result<()> {
+        db.run(&format!(
+            r#"
+            ALTER TABLE "{table}"
+            DROP CONSTRAINT IF EXISTS "{constraint_name}"
+            "#,
+            table = table,
+            constraint_name = self.temp_constraint_name(ctx),
+        ))
+        .context("failed to drop temporary check constraint")
+    }
+
+    fn violation_error(&self, violations: &[String]) -> anyhow::Error {
+        if violations.is_empty() {
+            anyhow!(
+                "existing rows in table \"{}\" violate check \"{}\"",
+                self.table,
+                self.check.name
+            )
+        } else {
+            anyhow!(
+                "existing rows in table \"{}\" violate check \"{}\", for example rows with {}",
+                self.table,
+                self.check.name,
+                violations.join("; ")
+            )
+        }
+    }
+}

--- a/src/migrations/add_check.rs
+++ b/src/migrations/add_check.rs
@@ -19,9 +19,6 @@ pub struct CheckDefinition {
     pub expression: String,
 }
 
-// The number of violating rows to include in an error
-const VIOLATION_EXAMPLES: usize = 5;
-
 #[typetag::serde(name = "add_check")]
 impl Action for AddCheck {
     fn describe(&self) -> String {
@@ -97,16 +94,10 @@ impl Action for AddCheck {
             // until the migration is aborted
             self.drop_temp_constraint(ctx, db, &table.real_name)?;
 
-            // Postgres doesn't say which rows failed validation, so look some up for
-            // the error
-            let violations = common::find_check_violations(
-                db,
-                &table.real_name,
-                &expression,
-                VIOLATION_EXAMPLES,
-            )
-            .unwrap_or_default();
-            return Err(error.context(self.violation_error(&violations)));
+            return Err(error.context(format!(
+                "existing rows in table \"{}\" violate check \"{}\"",
+                self.table, self.check.name
+            )));
         }
 
         Ok(())
@@ -180,22 +171,5 @@ impl AddCheck {
             constraint_name = self.temp_constraint_name(ctx),
         ))
         .context("failed to drop temporary check constraint")
-    }
-
-    fn violation_error(&self, violations: &[String]) -> anyhow::Error {
-        if violations.is_empty() {
-            anyhow!(
-                "existing rows in table \"{}\" violate check \"{}\"",
-                self.table,
-                self.check.name
-            )
-        } else {
-            anyhow!(
-                "existing rows in table \"{}\" violate check \"{}\", for example rows with {}",
-                self.table,
-                self.check.name,
-                violations.join("; ")
-            )
-        }
     }
 }

--- a/src/migrations/add_check.rs
+++ b/src/migrations/add_check.rs
@@ -59,23 +59,9 @@ impl Action for AddCheck {
 
         let temp_constraint_name = self.temp_constraint_name(ctx);
 
+        // Skipped when a previous attempt at applying the migration already created the
+        // constraint, as ADD CONSTRAINT has no IF NOT EXISTS form
         if !common::check_constraint_exists(db, &table.real_name, &temp_constraint_name)? {
-            // Look for existing rows which violate the check before adding it. Once added,
-            // the check is enforced on every write, including those of the old schema, so
-            // a check which the existing data doesn't satisfy should fail before that
-            // point. This is only an early exit: the scan doesn't block the application
-            // but rows written after it are only covered by the validation below.
-            let violations = common::find_check_violations(
-                db,
-                &table.real_name,
-                &expression,
-                VIOLATION_EXAMPLES,
-            )
-            .context("failed to check existing rows against check")?;
-            if !violations.is_empty() {
-                return Err(self.violation_error(&violations));
-            }
-
             // Create the check but set it as NOT VALID. This means the check is enforced
             // for inserts and updates but the existing data isn't checked, which would
             // require a long-lived lock.
@@ -95,7 +81,8 @@ impl Action for AddCheck {
 
         // Validating scans the table but doesn't block reads or writes. Together with the
         // NOT VALID constraint, which covers every row written since it was added, this
-        // proves that every row satisfies the check.
+        // proves that every row satisfies the check. Validating is also what catches a
+        // check which the existing data doesn't satisfy.
         let validation = db.run(&format!(
             r#"
             ALTER TABLE "{table}"
@@ -110,6 +97,8 @@ impl Action for AddCheck {
             // until the migration is aborted
             self.drop_temp_constraint(ctx, db, &table.real_name)?;
 
+            // Postgres doesn't say which rows failed validation, so look some up for
+            // the error
             let violations = common::find_check_violations(
                 db,
                 &table.real_name,

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -176,13 +176,14 @@ impl Action for AlterColumn {
         // Dropping the old column on completion also drops every check constraint involving
         // it, so these copies are what remain afterwards. Each copy is validated right away
         // so that an `up` transformation which breaks a check fails the migration while it
-        // can still be aborted.
+        // can still be aborted. Checks which the migration removes aren't copied, as they
+        // are dropped on completion anyway.
         let checks =
             common::get_check_constraints_for_column(db, &table.real_name, &column.real_name)?;
-        for check in checks
-            .into_iter()
-            .filter(|check| !common::is_temporary_not_null_constraint(&check.name))
-        {
+        for check in checks.into_iter().filter(|check| {
+            !common::is_temporary_not_null_constraint(&check.name)
+                && !schema.is_check_removed(&self.table, &check.name)
+        }) {
             let temp_check_name = self.temp_check_name(ctx, check.oid);
 
             if !common::check_constraint_exists(db, &table.real_name, &temp_check_name)? {

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -369,6 +369,63 @@ pub fn is_temporary_not_null_constraint(name: &str) -> bool {
         && (name.ends_with("_alter_column_temporary") || name.contains("_add_column_not_null_"))
 }
 
+// Finds up to `limit` rows of a table which don't satisfy a check expression, described
+// by their primary key, or by ctid if the table has none. The expression must reference
+// the real columns of the table. A NULL result satisfies a check, so only rows where
+// the expression is false are returned.
+//
+// This is a plain read which doesn't block the application, but it isn't authoritative:
+// rows written after it has run are not covered.
+pub fn find_check_violations(
+    db: &mut dyn Conn,
+    table: &str,
+    expression: &str,
+    limit: usize,
+) -> anyhow::Result<Vec<String>> {
+    let mut key_columns = get_primary_key_columns_for_table(db, table)?;
+    if key_columns.is_empty() {
+        key_columns.push("ctid".to_string());
+    }
+
+    let selection: Vec<String> = key_columns
+        .iter()
+        .map(|column| format!(r#""{}"::text"#, column))
+        .collect();
+
+    let rows = db.query(&format!(
+        r#"
+        SELECT {selection}
+        FROM "{table}"
+        WHERE ({expression}) IS FALSE
+        LIMIT {limit}
+        "#,
+        selection = selection.join(", "),
+        table = table,
+        expression = expression,
+        limit = limit,
+    ))?;
+
+    let violations = rows
+        .iter()
+        .map(|row| {
+            let values: Vec<String> = (0..key_columns.len())
+                .map(|index| {
+                    row.get::<_, Option<String>>(index)
+                        .unwrap_or_else(|| "NULL".to_string())
+                })
+                .collect();
+
+            if key_columns.len() == 1 {
+                format!("{} = {}", key_columns[0], values[0])
+            } else {
+                format!("({}) = ({})", key_columns.join(", "), values.join(", "))
+            }
+        })
+        .collect();
+
+    Ok(violations)
+}
+
 pub fn check_constraint_exists(
     db: &mut dyn Conn,
     table: &str,

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -369,64 +369,6 @@ pub fn is_temporary_not_null_constraint(name: &str) -> bool {
         && (name.ends_with("_alter_column_temporary") || name.contains("_add_column_not_null_"))
 }
 
-// Finds up to `limit` rows of a table which don't satisfy a check expression, described
-// by their primary key, or by ctid if the table has none. The expression must reference
-// the real columns of the table. A NULL result satisfies a check, so only rows where
-// the expression is false are returned.
-//
-// This is a plain read for describing violations in errors. It isn't authoritative, as
-// rows written after it has run are not covered, so it doesn't replace validating a
-// constraint.
-pub fn find_check_violations(
-    db: &mut dyn Conn,
-    table: &str,
-    expression: &str,
-    limit: usize,
-) -> anyhow::Result<Vec<String>> {
-    let mut key_columns = get_primary_key_columns_for_table(db, table)?;
-    if key_columns.is_empty() {
-        key_columns.push("ctid".to_string());
-    }
-
-    let selection: Vec<String> = key_columns
-        .iter()
-        .map(|column| format!(r#""{}"::text"#, column))
-        .collect();
-
-    let rows = db.query(&format!(
-        r#"
-        SELECT {selection}
-        FROM "{table}"
-        WHERE ({expression}) IS FALSE
-        LIMIT {limit}
-        "#,
-        selection = selection.join(", "),
-        table = table,
-        expression = expression,
-        limit = limit,
-    ))?;
-
-    let violations = rows
-        .iter()
-        .map(|row| {
-            let values: Vec<String> = (0..key_columns.len())
-                .map(|index| {
-                    row.get::<_, Option<String>>(index)
-                        .unwrap_or_else(|| "NULL".to_string())
-                })
-                .collect();
-
-            if key_columns.len() == 1 {
-                format!("{} = {}", key_columns[0], values[0])
-            } else {
-                format!("({}) = ({})", key_columns.join(", "), values.join(", "))
-            }
-        })
-        .collect();
-
-    Ok(violations)
-}
-
 pub fn check_constraint_exists(
     db: &mut dyn Conn,
     table: &str,

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -374,8 +374,9 @@ pub fn is_temporary_not_null_constraint(name: &str) -> bool {
 // the real columns of the table. A NULL result satisfies a check, so only rows where
 // the expression is false are returned.
 //
-// This is a plain read which doesn't block the application, but it isn't authoritative:
-// rows written after it has run are not covered.
+// This is a plain read for describing violations in errors. It isn't authoritative, as
+// rows written after it has run are not covered, so it doesn't replace validating a
+// constraint.
 pub fn find_check_violations(
     db: &mut dyn Conn,
     table: &str,

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -392,6 +392,12 @@ pub use add_foreign_key::AddForeignKey;
 mod remove_foreign_key;
 pub use remove_foreign_key::RemoveForeignKey;
 
+mod add_check;
+pub use add_check::AddCheck;
+
+mod remove_check;
+pub use remove_check::RemoveCheck;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Migration {
     pub name: String,

--- a/src/migrations/remove_check.rs
+++ b/src/migrations/remove_check.rs
@@ -27,12 +27,6 @@ impl Action for RemoveCheck {
         db: &mut dyn Conn,
         schema: &Schema,
     ) -> anyhow::Result<()> {
-        // The check is only removed once the migration is completed, for the same
-        // reasons as a foreign key: removing it earlier would let the new schema write
-        // rows which the old schema still expects to satisfy the check, and if the
-        // migration was aborted the check would have to be recreated with the risk that
-        // the data no longer satisfies it.
-
         // Ensure check exists
         let table = schema.get_table(db, &self.table)?;
         if !common::check_constraint_exists(db, &table.real_name, &self.check)? {

--- a/src/migrations/remove_check.rs
+++ b/src/migrations/remove_check.rs
@@ -1,0 +1,80 @@
+use super::{common, Action, MigrationContext, NameField};
+use crate::{
+    db::{Conn, Transaction},
+    schema::Schema,
+};
+use anyhow::{anyhow, Context};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RemoveCheck {
+    table: String,
+    check: String,
+}
+
+#[typetag::serde(name = "remove_check")]
+impl Action for RemoveCheck {
+    fn describe(&self) -> String {
+        format!(
+            "Removing check constraint \"{}\" from table \"{}\"",
+            self.check, self.table
+        )
+    }
+
+    fn run(
+        &self,
+        _ctx: &MigrationContext,
+        db: &mut dyn Conn,
+        schema: &Schema,
+    ) -> anyhow::Result<()> {
+        // The check is only removed once the migration is completed, for the same
+        // reasons as a foreign key: removing it earlier would let the new schema write
+        // rows which the old schema still expects to satisfy the check, and if the
+        // migration was aborted the check would have to be recreated with the risk that
+        // the data no longer satisfies it.
+
+        // Ensure check exists
+        let table = schema.get_table(db, &self.table)?;
+        if !common::check_constraint_exists(db, &table.real_name, &self.check)? {
+            return Err(anyhow!(
+                "no check constraint \"{}\" exists on table \"{}\"",
+                self.check,
+                self.table
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn complete<'a>(
+        &self,
+        _ctx: &MigrationContext,
+        db: &'a mut dyn Conn,
+    ) -> anyhow::Result<Option<Transaction<'a>>> {
+        db.run(&format!(
+            r#"
+            ALTER TABLE "{table}"
+            DROP CONSTRAINT IF EXISTS "{check}"
+            "#,
+            table = self.table,
+            check = self.check,
+        ))
+        .context("failed to remove check constraint")?;
+        Ok(None)
+    }
+
+    fn update_schema(&self, _ctx: &MigrationContext, schema: &mut Schema) {
+        let check = self.check.clone();
+        schema.change_table(&self.table, |table_changes| {
+            table_changes.set_check_removed(&check);
+        });
+    }
+
+    fn abort(&self, _ctx: &MigrationContext, _db: &mut dyn Conn) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn name_fields(&self) -> Vec<NameField> {
+        vec![NameField::table("table", &self.table)]
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -51,6 +51,17 @@ impl Schema {
         let table_changes = &mut self.table_changes[table_change_index];
         f(table_changes)
     }
+
+    /// Whether a check constraint on a table is removed by an earlier action of the
+    /// migration. The constraint still exists in the database until the migration
+    /// completes, but shouldn't be treated as part of the schema.
+    pub fn is_check_removed(&self, table_name: &str, check_name: &str) -> bool {
+        self.table_changes
+            .iter()
+            .find(|changes| changes.current_name == table_name)
+            .map(|changes| changes.removed_checks.iter().any(|name| name == check_name))
+            .unwrap_or(false)
+    }
 }
 
 impl Default for Schema {
@@ -65,6 +76,7 @@ pub struct TableChanges {
     real_name: String,
     column_changes: Vec<ColumnChanges>,
     removed: bool,
+    removed_checks: Vec<String>,
 }
 
 impl TableChanges {
@@ -74,7 +86,16 @@ impl TableChanges {
             real_name: name,
             column_changes: Vec::new(),
             removed: false,
+            removed_checks: Vec::new(),
         }
+    }
+
+    pub fn set_check_removed(&mut self, name: &str) {
+        self.removed_checks.push(name.to_string());
+    }
+
+    pub fn set_check_added(&mut self, name: &str) {
+        self.removed_checks.retain(|removed| removed != name);
     }
 
     pub fn set_name(&mut self, name: &str) {

--- a/tests/add_check.rs
+++ b/tests/add_check.rs
@@ -1,0 +1,350 @@
+mod common;
+use common::{assert_invalid, check_constraint_definitions, Test};
+
+#[test]
+fn add_check() {
+    let mut test = Test::new("Add check");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "age"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_age_check"
+
+        [[actions]]
+        type = "add_check"
+        table = "users"
+
+            [actions.check]
+            name = "users_age_check"
+            expression = "age >= 0"
+        "#,
+    );
+
+    test.after_first(|db| {
+        // Rows which satisfy the check, including a NULL which always passes
+        db.simple_query("INSERT INTO users (id, age) VALUES (1, 10), (2, NULL)")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // The check is enforced for both schemas as soon as the migration is applied
+        old_db
+            .simple_query("INSERT INTO users (id, age) VALUES (3, 30)")
+            .unwrap();
+        new_db
+            .simple_query("INSERT INTO users (id, age) VALUES (4, 40)")
+            .unwrap();
+
+        let result = old_db.simple_query("INSERT INTO users (id, age) VALUES (5, -1)");
+        assert!(
+            result.is_err(),
+            "expected insert against old schema to fail"
+        );
+
+        let result = new_db.simple_query("INSERT INTO users (id, age) VALUES (5, -1)");
+        assert!(
+            result.is_err(),
+            "expected insert against new schema to fail"
+        );
+
+        // The temporary constraint has been validated
+        let definitions = check_constraint_definitions(old_db, "__reshape%");
+        assert_eq!(1, definitions.len(), "got: {:?}", definitions);
+    });
+
+    test.after_completion(|db| {
+        let result = db.simple_query("INSERT INTO users (id, age) VALUES (5, -1)");
+        assert!(result.is_err(), "expected insert to fail");
+
+        // The check exists under its final name
+        let definitions = check_constraint_definitions(db, "users_age_check");
+        assert_eq!(1, definitions.len(), "got: {:?}", definitions);
+        assert!(
+            definitions[0].contains("age >= 0"),
+            "got: {}",
+            definitions[0]
+        );
+        assert!(check_constraint_definitions(db, "__reshape%").is_empty());
+    });
+
+    test.after_abort(|db| {
+        // The check doesn't exist
+        db.simple_query("INSERT INTO users (id, age) VALUES (5, -1)")
+            .unwrap();
+        assert!(check_constraint_definitions(db, "users_age_check").is_empty());
+        assert!(check_constraint_definitions(db, "__reshape%").is_empty());
+    });
+
+    test.run()
+}
+
+#[test]
+fn add_check_with_violating_rows() {
+    let mut test = Test::new("Add check with rows which violate it");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "age"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_age_check"
+
+        [[actions]]
+        type = "add_check"
+        table = "users"
+
+            [actions.check]
+            name = "users_age_check"
+            expression = "age >= 0"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, age) VALUES (1, 10), (2, -5)")
+            .unwrap();
+    });
+
+    test.expect_failure();
+
+    test.intermediate(|old_db, _| {
+        // The failed check was never left behind, so the old schema is unaffected
+        old_db
+            .simple_query("INSERT INTO users (id, age) VALUES (3, -1)")
+            .unwrap();
+        assert!(check_constraint_definitions(old_db, "__reshape%").is_empty());
+    });
+
+    test.run()
+}
+
+#[test]
+fn add_check_with_existing_name() {
+    let mut test = Test::new("Add check with the name of an existing check");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "age"
+            type = "INTEGER"
+
+            [[actions.checks]]
+            name = "users_age_check"
+            expression = "age >= 0"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_age_check"
+
+        [[actions]]
+        type = "add_check"
+        table = "users"
+
+            [actions.check]
+            name = "users_age_check"
+            expression = "age >= 18"
+        "#,
+    );
+
+    test.expect_failure();
+
+    test.intermediate(|old_db, _| {
+        assert!(check_constraint_definitions(old_db, "__reshape%").is_empty());
+    });
+
+    test.run()
+}
+
+#[test]
+fn add_check_on_altered_column() {
+    let mut test = Test::new("Add check on a column altered in the same migration");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "age"
+            type = "INTEGER"
+        "#,
+    );
+
+    // The check references the column by its new name, which is backed by a temporary
+    // column during the migration
+    test.second_migration(
+        r#"
+        name = "rename_age_and_add_check"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "age"
+        up = "age"
+        down = "age"
+
+            [actions.changes]
+            name = "years"
+            type = "BIGINT"
+
+        [[actions]]
+        type = "add_check"
+        table = "users"
+
+            [actions.check]
+            name = "users_years_check"
+            expression = "years >= 0"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, age) VALUES (1, 10)")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        let result = old_db.simple_query("INSERT INTO users (id, age) VALUES (2, -1)");
+        assert!(
+            result.is_err(),
+            "expected insert against old schema to fail"
+        );
+
+        let result = new_db.simple_query("INSERT INTO users (id, years) VALUES (2, -1)");
+        assert!(
+            result.is_err(),
+            "expected insert against new schema to fail"
+        );
+
+        new_db
+            .simple_query("INSERT INTO users (id, years) VALUES (2, 20)")
+            .unwrap();
+    });
+
+    test.after_completion(|db| {
+        let definitions = check_constraint_definitions(db, "users_years_check");
+        assert_eq!(1, definitions.len(), "got: {:?}", definitions);
+        assert!(
+            definitions[0].contains("years >= 0"),
+            "got: {}",
+            definitions[0]
+        );
+
+        let result = db.simple_query("INSERT INTO users (id, years) VALUES (3, -1)");
+        assert!(result.is_err(), "expected insert to fail");
+    });
+
+    test.after_abort(|db| {
+        db.simple_query("INSERT INTO users (id, age) VALUES (3, -1)")
+            .unwrap();
+        assert!(check_constraint_definitions(db, "%check").is_empty());
+    });
+
+    test.run()
+}
+
+#[test]
+fn add_check_with_unknown_column() {
+    let mut test = Test::new("Add check referencing an unknown column");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_age_check"
+
+        [[actions]]
+        type = "add_check"
+        table = "users"
+
+            [actions.check]
+            name = "users_age_check"
+            expression = "age >= 0"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run()
+}
+
+#[test]
+fn add_check_invalid_sql() {
+    assert_invalid(
+        r#"
+        name = "test"
+        [[actions]]
+        type = "add_check"
+        table = "users"
+
+            [actions.check]
+            name = "users_age_check"
+            expression = "age >= )"
+        "#,
+    );
+}

--- a/tests/add_check.rs
+++ b/tests/add_check.rs
@@ -141,7 +141,8 @@ fn add_check_with_violating_rows() {
     test.expect_failure();
 
     test.intermediate(|old_db, _| {
-        // The failed check was never left behind, so the old schema is unaffected
+        // The check is dropped again when validation fails, so the old schema is
+        // unaffected
         old_db
             .simple_query("INSERT INTO users (id, age) VALUES (3, -1)")
             .unwrap();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -231,8 +231,9 @@ impl Test<'_> {
                     .reshape
                     .migrate(vec![first_migration.clone(), second_migration.clone()]);
 
-                if result.is_ok() {
-                    panic!("expected second migration to fail");
+                match result {
+                    Ok(_) => panic!("expected second migration to fail"),
+                    Err(error) => println!("Failed as expected: {:#}", error),
                 }
             } else {
                 print_subheading("Applying second migration");
@@ -314,6 +315,27 @@ fn add_spacer(text: &str, char: &str) -> String {
     };
 
     format!("{spacer} {text} {spacer}{extra}", spacer = spacer)
+}
+
+// The definitions of the check constraints on tables in the public schema whose names
+// match a LIKE pattern, ordered by name
+#[allow(dead_code)]
+pub fn check_constraint_definitions(db: &mut Client, name_pattern: &str) -> Vec<String> {
+    db.query(
+        "
+        SELECT pg_get_constraintdef(c.oid) AS definition
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.contype = 'c' AND n.nspname = 'public' AND c.conname LIKE $1
+        ORDER BY c.conname
+        ",
+        &[&name_pattern],
+    )
+    .unwrap()
+    .iter()
+    .map(|row| row.get("definition"))
+    .collect()
 }
 
 pub fn assert_cleaned_up(db: &mut Client) {

--- a/tests/remove_check.rs
+++ b/tests/remove_check.rs
@@ -1,0 +1,297 @@
+mod common;
+use common::{check_constraint_definitions, Test};
+
+#[test]
+fn remove_check() {
+    let mut test = Test::new("Remove check");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "age"
+            type = "INTEGER"
+
+            [[actions.checks]]
+            name = "users_age_check"
+            expression = "age >= 0"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "remove_age_check"
+
+        [[actions]]
+        type = "remove_check"
+        table = "users"
+        check = "users_age_check"
+        "#,
+    );
+
+    test.intermediate(|old_db, new_db| {
+        // The check is only removed when the migration is completed so it should still
+        // be enforced for the new and old schema
+        let result = old_db.simple_query("INSERT INTO users (id, age) VALUES (1, -1)");
+        assert!(
+            result.is_err(),
+            "expected insert against old schema to fail"
+        );
+
+        let result = new_db.simple_query("INSERT INTO users (id, age) VALUES (1, -1)");
+        assert!(
+            result.is_err(),
+            "expected insert against new schema to fail"
+        );
+    });
+
+    test.after_completion(|db| {
+        db.simple_query("INSERT INTO users (id, age) VALUES (1, -1)")
+            .unwrap();
+        assert!(check_constraint_definitions(db, "users_age_check").is_empty());
+    });
+
+    test.after_abort(|db| {
+        let result = db.simple_query("INSERT INTO users (id, age) VALUES (1, -1)");
+        assert!(result.is_err(), "expected insert to fail");
+        assert_eq!(1, check_constraint_definitions(db, "users_age_check").len());
+    });
+
+    test.run()
+}
+
+#[test]
+fn remove_nonexistent_check() {
+    let mut test = Test::new("Remove check which doesn't exist");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "remove_age_check"
+
+        [[actions]]
+        type = "remove_check"
+        table = "users"
+        check = "users_age_check"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run()
+}
+
+#[test]
+fn replace_check_with_same_name() {
+    let mut test = Test::new("Replace check by removing and adding it with the same name");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "age"
+            type = "INTEGER"
+
+            [[actions.checks]]
+            name = "users_age_check"
+            expression = "age >= 0"
+        "#,
+    );
+
+    // Widen the check to allow negative ages down to -10
+    test.second_migration(
+        r#"
+        name = "widen_age_check"
+
+        [[actions]]
+        type = "remove_check"
+        table = "users"
+        check = "users_age_check"
+
+        [[actions]]
+        type = "add_check"
+        table = "users"
+
+            [actions.check]
+            name = "users_age_check"
+            expression = "age >= -10"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, age) VALUES (1, 10)")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // Both checks exist during the migration: the old one until completion and the
+        // new one from the start, so writes must satisfy both
+        assert_eq!(
+            1,
+            check_constraint_definitions(old_db, "users_age_check").len()
+        );
+        assert_eq!(1, check_constraint_definitions(old_db, "__reshape%").len());
+
+        let result = old_db.simple_query("INSERT INTO users (id, age) VALUES (2, -5)");
+        assert!(
+            result.is_err(),
+            "expected insert against old schema to fail"
+        );
+
+        let result = new_db.simple_query("INSERT INTO users (id, age) VALUES (2, -5)");
+        assert!(
+            result.is_err(),
+            "expected insert against new schema to fail"
+        );
+
+        let result = new_db.simple_query("INSERT INTO users (id, age) VALUES (2, -20)");
+        assert!(
+            result.is_err(),
+            "expected insert against new schema to fail"
+        );
+
+        new_db
+            .simple_query("INSERT INTO users (id, age) VALUES (2, 0)")
+            .unwrap();
+    });
+
+    test.after_completion(|db| {
+        // Only the new check remains, under the original name
+        let definitions = check_constraint_definitions(db, "users_age_check");
+        assert_eq!(1, definitions.len(), "got: {:?}", definitions);
+        assert!(
+            definitions[0].contains("-10"),
+            "expected widened check, got: {}",
+            definitions[0]
+        );
+        assert!(check_constraint_definitions(db, "__reshape%").is_empty());
+
+        db.simple_query("INSERT INTO users (id, age) VALUES (3, -5)")
+            .unwrap();
+        let result = db.simple_query("INSERT INTO users (id, age) VALUES (4, -20)");
+        assert!(result.is_err(), "expected insert to fail");
+    });
+
+    test.after_abort(|db| {
+        // The original check is untouched
+        let definitions = check_constraint_definitions(db, "users_age_check");
+        assert_eq!(1, definitions.len(), "got: {:?}", definitions);
+        assert!(
+            definitions[0].contains("age >= 0"),
+            "expected original check, got: {}",
+            definitions[0]
+        );
+        assert!(check_constraint_definitions(db, "__reshape%").is_empty());
+
+        let result = db.simple_query("INSERT INTO users (id, age) VALUES (3, -5)");
+        assert!(result.is_err(), "expected insert to fail");
+    });
+
+    test.run()
+}
+
+#[test]
+fn remove_check_and_alter_column() {
+    let mut test = Test::new("Remove check and alter the column it references");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "age"
+            type = "INTEGER"
+
+            [[actions.checks]]
+            name = "users_age_check"
+            expression = "age >= 0"
+        "#,
+    );
+
+    // The removed check must not be carried over to the altered column
+    test.second_migration(
+        r#"
+        name = "remove_age_check_and_alter_age"
+
+        [[actions]]
+        type = "remove_check"
+        table = "users"
+        check = "users_age_check"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "age"
+        up = "age"
+        down = "age"
+
+            [actions.changes]
+            type = "BIGINT"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, age) VALUES (1, 10)")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, _| {
+        assert!(check_constraint_definitions(old_db, "__reshape%").is_empty());
+    });
+
+    test.after_completion(|db| {
+        assert!(check_constraint_definitions(db, "%check").is_empty());
+        db.simple_query("INSERT INTO users (id, age) VALUES (2, -1)")
+            .unwrap();
+    });
+
+    test.after_abort(|db| {
+        assert_eq!(1, check_constraint_definitions(db, "users_age_check").len());
+        let result = db.simple_query("INSERT INTO users (id, age) VALUES (2, -1)");
+        assert!(result.is_err(), "expected insert to fail");
+    });
+
+    test.run()
+}


### PR DESCRIPTION
## What

Two new actions, modeled on `add_foreign_key` and `remove_foreign_key`.

```toml
[[actions]]
type = "add_check"
table = "users"

    [actions.check]
    name = "users_age_check"
    expression = "age >= 0"

[[actions]]
type = "remove_check"
table = "users"
check = "users_age_check"
```

## add_check

- **`NOT VALID` + `VALIDATE`**, exactly like foreign keys. The `NOT VALID` constraint covers every row written after it appears and validate covers everything before, so together they prove every row satisfies the check. Neither blocks application reads or writes.
- **Validation failure drops the constraint** before returning the error, so a failed migration doesn't leave the check enforced on the old schema until someone runs abort.
- The expression is rewritten through the schema with `rewrite_column_references`, so it can reference a column altered or renamed in the same migration.
- Fails at run time if a constraint with the final name already exists, unless the same migration removes it (see below).
- Complete renames the temporary constraint to its final name. Abort drops it. Run, complete and abort are all re-runnable; `ADD CONSTRAINT` has no `IF NOT EXISTS`, hence the existence check before it.

## remove_check

Verifies the constraint exists at run time and drops it on completion. Abort is a no-op. Same reasoning as `remove_foreign_key`: dropping earlier would let the new schema write rows the old schema still expects to satisfy the check, and abort would then have to recreate a constraint the data may violate.

## Replacing a check with the same name

`remove_check` followed by `add_check` with the same name in one migration works. `Schema` now tracks checks removed by earlier actions of the migration, which is used in two places:

- `add_check` accepts a name that is still taken by a constraint the migration removes. Completion runs actions in order, so the old one is dropped before the new one is renamed.
- `alter_column` (from #58) no longer carries a removed check over to the new column, which would otherwise leave an orphaned copy.

During the migration both the old and the new check are enforced, so writes must satisfy both until completion. That is the same behavior as removing a foreign key, and it is documented.

## Docs and tests

- `src/docs/actions/add-check.md`, `remove-check.md` and the index table.
- Tests for both actions: basic add and remove through completion and abort, violating existing rows, existing name, referencing a column renamed in the same migration, unknown column, invalid SQL, nonexistent check, replacing with the same name, and removing a check while altering its column.
- The test harness now prints the error when a migration is expected to fail.

README is not touched.
