### PR TITLE
Keep generated names within Postgres' identifier limit

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -11,11 +11,11 @@ pub fn set_up_helpers(db: &mut dyn Conn, target_migration: &str) -> anyhow::Resu
                 setting TEXT := current_setting('reshape.is_new_schema', TRUE);
                 setting_bool BOOLEAN := setting IS NOT NULL AND setting = 'YES';
 			BEGIN
-				RETURN current_setting('search_path') = 'migration_{}' OR setting_bool;
+				RETURN current_setting('search_path') = '{}' OR setting_bool;
 			END
 			$$ language 'plpgsql';
         ",
-        target_migration,
+        crate::schema_name_for_migration(target_migration),
     );
     db.query(&query)
         .context("failed creating helper function reshape.is_new_schema()")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,8 @@ pub fn schema_query_for_migration(migration_name: &str) -> String {
     format!("SET search_path TO {}", schema_name)
 }
 
-fn schema_name_for_migration(migration_name: &str) -> String {
-    format!("migration_{}", migration_name)
+pub(crate) fn schema_name_for_migration(migration_name: &str) -> String {
+    migrations::common::bounded_identifier("migration_", migration_name, "")
 }
 
 fn migrate(

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -29,39 +29,19 @@ pub enum Transformation {
 
 impl AddColumn {
     fn temp_column_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_temp_column_{}_{}",
-            ctx.prefix(),
-            self.table,
-            self.column.name,
-        )
+        ctx.name("temp_column", &[&self.table, &self.column.name], "")
     }
 
     fn trigger_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_add_column_{}_{}",
-            ctx.prefix(),
-            self.table,
-            self.column.name
-        )
+        ctx.name("add_column", &[&self.table, &self.column.name], "")
     }
 
     fn reverse_trigger_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_add_column_{}_{}_rev",
-            ctx.prefix(),
-            self.table,
-            self.column.name
-        )
+        ctx.name("add_column", &[&self.table, &self.column.name], "_rev")
     }
 
     fn not_null_constraint_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_add_column_not_null_{}_{}",
-            ctx.prefix(),
-            self.table,
-            self.column.name
-        )
+        ctx.name("add_column_not_null", &[&self.table, &self.column.name], "")
     }
 }
 

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -8,6 +8,10 @@ use crate::{
 use anyhow::{anyhow, Context};
 use serde::{Deserialize, Serialize};
 
+// Prefix given to an index which has been replaced by its temporary counterpart and is
+// about to be dropped
+const OLD_INDEX_PREFIX: &str = "__reshape_old_";
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AlterColumn {
     pub table: String,
@@ -317,44 +321,34 @@ impl Action for AlterColumn {
                 .context("failed to drop NOT NULL constraint")?;
         }
 
-        // Replace old indices with the new temporary ones created for the temporary column
+        // Replace old indices with the new temporary ones created for the temporary column.
+        // The old index is moved out of the way and the temporary one takes over its name
+        // in a single transaction, and the old index is then dropped concurrently. An index
+        // which already carries the prefix belongs to an earlier, interrupted completion
+        // which got as far as the swap, so only the drop remains for it.
         let indices = common::get_indices_for_column(db, &self.table, &self.column)?;
         for current_index in indices {
-            // To keep the index handling idempotent, we need to do the following:
-            // 1. Add a prefix to the existing index
-            // 2. Rename temporary index to its final name
-            // 3. Drop existing index concurrently
+            let old_index_name = if current_index.name.starts_with(OLD_INDEX_PREFIX) {
+                current_index.name.clone()
+            } else {
+                let old_index_name =
+                    common::bounded_identifier(OLD_INDEX_PREFIX, &current_index.name, "");
+                let temp_index_name = self.temp_index_name(ctx, current_index.oid);
+                db.run(&format!(
+                    r#"
+                    ALTER INDEX IF EXISTS "{current_name}" RENAME TO "{old_index_name}";
+                    ALTER INDEX IF EXISTS "{temp_index_name}" RENAME TO "{current_name}";
+                    "#,
+                    current_name = current_index.name,
+                ))
+                .context("failed to swap old index for temporary index")?;
+                old_index_name
+            };
 
-            // Add prefix (if not already added) to existing index
-            let prefix = "__reshape_old";
-            let target_index_name = current_index.name.trim_start_matches(prefix);
-            let old_index_name = format!("{}_{}", prefix, target_index_name);
-            db.query(&format!(
-                r#"
-                ALTER INDEX IF EXISTS "{current_name}" RENAME TO "{new_name}"
-                "#,
-                current_name = target_index_name,
-                new_name = old_index_name,
-            ))
-            .context("failed to rename old index")?;
-
-            // Rename temporary index to real name
-            let temp_index_name = self.temp_index_name(ctx, current_index.oid);
-            db.query(&format!(
-                r#"
-                ALTER INDEX IF EXISTS "{temp_index_name}" RENAME TO "{target_index_name}"
-                "#,
-                temp_index_name = temp_index_name,
-                target_index_name = target_index_name,
-            ))
-            .context("failed to rename temporary index")?;
-
-            // Drop old index concurrently
             db.query(&format!(
                 r#"
                 DROP INDEX CONCURRENTLY IF EXISTS "{old_index_name}"
                 "#,
-                old_index_name = old_index_name,
             ))
             .context("failed to drop old index")?;
         }
@@ -558,7 +552,7 @@ impl Action for AlterColumn {
 
 impl AlterColumn {
     fn temporary_column_name(&self, ctx: &MigrationContext) -> String {
-        format!("{}_new_{}", ctx.prefix(), self.column)
+        ctx.name("new", &[&self.column], "")
     }
 
     fn up_trigger_name(&self, ctx: &MigrationContext) -> String {

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -418,7 +418,7 @@ pub fn rename_not_null_constraint(
     table: &str,
     column: &str,
 ) -> anyhow::Result<()> {
-    let target_name = format!("{table}_{column}_not_null");
+    let target_name = bounded_identifier("", &format!("{table}_{column}"), "_not_null");
 
     let current_name: Option<String> = db
         .query_with_params(
@@ -504,4 +504,95 @@ pub fn table_with_current_columns(table: &Table) -> String {
         real_name = table.real_name,
         name = table.name,
     )
+}
+
+/// The longest identifier Postgres accepts. Longer names are silently cut down to this
+/// length, which makes generated names which only differ at the end collide.
+pub const MAX_IDENTIFIER_LENGTH: usize = 63;
+
+/// Builds the identifier `{head}{body}{tail}`, shortened to fit within Postgres' limit on
+/// identifier length. Names which already fit are returned unchanged. Longer names keep
+/// `head` and `tail` intact, as those are the parts which tell related objects apart, and
+/// have their `body` cut down with a hash of the complete name in its place so that
+/// distinct names stay distinct.
+pub fn bounded_identifier(head: &str, body: &str, tail: &str) -> String {
+    let full = format!("{head}{body}{tail}");
+    if full.len() <= MAX_IDENTIFIER_LENGTH {
+        return full;
+    }
+
+    let hash = format!("{:08x}", fnv1a_hash(&full) as u32);
+    let budget = MAX_IDENTIFIER_LENGTH
+        .saturating_sub(head.len() + tail.len() + hash.len() + 1)
+        .min(body.len());
+    let mut cut = budget;
+    while !body.is_char_boundary(cut) {
+        cut -= 1;
+    }
+
+    format!("{head}{}_{hash}{tail}", &body[..cut])
+}
+
+// 64-bit FNV-1a. Names are recomputed on every run, so the hash has to be stable
+// across processes and versions, which rules out the standard library's hasher.
+fn fnv1a_hash(input: &str) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in input.bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_identifier_keeps_short_names() {
+        assert_eq!(
+            "__reshape_0000_0000_add_column_users_email_rev",
+            bounded_identifier("__reshape_0000_0000_add_column_", "users_email", "_rev")
+        );
+    }
+
+    #[test]
+    fn bounded_identifier_shortens_long_names() {
+        let head = "__reshape_0000_0000_add_column_";
+        let body = "organization_membership_profiles_primary_contact_email_address";
+
+        let name = bounded_identifier(head, body, "");
+        let reverse = bounded_identifier(head, body, "_rev");
+
+        assert_eq!(MAX_IDENTIFIER_LENGTH, name.len());
+        assert_eq!(MAX_IDENTIFIER_LENGTH, reverse.len());
+        assert!(name.starts_with(head));
+        assert!(reverse.starts_with(head));
+        assert!(reverse.ends_with("_rev"));
+        assert_ne!(name, reverse);
+        assert_eq!(name, bounded_identifier(head, body, ""));
+    }
+
+    #[test]
+    fn bounded_identifier_tells_apart_names_with_the_same_start() {
+        let head = "__reshape_0000_0000_temp_column_";
+        let first = bounded_identifier(
+            head,
+            "organization_membership_profiles_primary_contact_email",
+            "",
+        );
+        let second = bounded_identifier(
+            head,
+            "organization_membership_profiles_primary_contact_email_address",
+            "",
+        );
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn bounded_identifier_respects_char_boundaries() {
+        let name = bounded_identifier("__reshape_0000_0000_add_column_", &"ä".repeat(40), "_rev");
+        assert!(name.len() <= MAX_IDENTIFIER_LENGTH);
+        assert!(name.ends_with("_rev"));
+    }
 }

--- a/src/migrations/create_table.rs
+++ b/src/migrations/create_table.rs
@@ -39,7 +39,7 @@ pub struct Transformation {
 
 impl CreateTable {
     fn trigger_name(&self, ctx: &MigrationContext) -> String {
-        format!("{}_create_table_{}", ctx.prefix(), self.name)
+        ctx.name("create_table", &[&self.name], "")
     }
 
     // The table as it will look once created

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -350,7 +350,7 @@ pub fn quote_string_literal(value: &str) -> String {
 }
 
 // Re-export migration types
-mod common;
+pub(crate) mod common;
 pub use common::Column;
 
 mod create_table;
@@ -460,6 +460,18 @@ impl MigrationContext {
             "__reshape_{:0>4}_{:0>4}",
             1000 - self.migration_index,
             1000 - self.action_index
+        )
+    }
+
+    /// Builds the name `{prefix}_{kind}_{parts joined by _}{suffix}` for an object created
+    /// by an action, shortened to fit within Postgres' identifier limit when needed. The
+    /// prefix, kind and suffix are always kept intact so that related objects, like a
+    /// trigger and its reverse, never end up with the same name.
+    fn name(&self, kind: &str, parts: &[&str], suffix: &str) -> String {
+        common::bounded_identifier(
+            &format!("{}_{}_", self.prefix(), kind),
+            &parts.join("_"),
+            suffix,
         )
     }
 }

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -26,39 +26,19 @@ pub enum Transformation {
 
 impl RemoveColumn {
     fn trigger_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_remove_column_{}_{}",
-            ctx.prefix(),
-            self.table,
-            self.column
-        )
+        ctx.name("remove_column", &[&self.table, &self.column], "")
     }
 
     fn reverse_trigger_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_remove_column_{}_{}_rev",
-            ctx.prefix(),
-            self.table,
-            self.column
-        )
+        ctx.name("remove_column", &[&self.table, &self.column], "_rev")
     }
 
     fn not_null_constraint_trigger_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_remove_column_{}_{}_nn",
-            ctx.prefix(),
-            self.table,
-            self.column
-        )
+        ctx.name("remove_column", &[&self.table, &self.column], "_nn")
     }
 
     fn not_null_constraint_name(&self, ctx: &MigrationContext) -> String {
-        format!(
-            "{}_add_column_not_null_{}_{}",
-            ctx.prefix(),
-            self.table,
-            self.column
-        )
+        ctx.name("add_column_not_null", &[&self.table, &self.column], "")
     }
 }
 

--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -1088,3 +1088,120 @@ fn add_column_with_comment() {
 
     test.run();
 }
+
+#[test]
+fn add_column_with_long_names() {
+    let mut test = Test::new("Add column with long names");
+
+    // The table and column names are long enough that the generated names would exceed
+    // Postgres' limit of 63 characters on identifiers, which used to make the forward
+    // and reverse triggers collapse into the same name
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+
+        [[actions]]
+        type = "create_table"
+        name = "organization_membership_profiles"
+        primary_key = ["user_id"]
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_organization_membership_profiles_primary_contact_email_address"
+
+        [[actions]]
+        type = "add_column"
+        table = "organization_membership_profiles"
+
+            [actions.column]
+            name = "primary_contact_email_address"
+            type = "TEXT"
+            nullable = false
+
+            [actions.up]
+            table = "users"
+            value = "users.email"
+            where = "organization_membership_profiles.user_id = users.id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, email) VALUES (1, 'test@example.com')")
+            .unwrap();
+        db.simple_query("INSERT INTO organization_membership_profiles (user_id) VALUES (1)")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // Every generated name should fit within the limit and be distinct
+        let trigger_names: Vec<String> = old_db
+            .query(
+                "SELECT tgname::text FROM pg_trigger WHERE tgname LIKE '__reshape%' ORDER BY 1",
+                &[],
+            )
+            .unwrap()
+            .iter()
+            .map(|row| row.get(0))
+            .collect();
+        assert_eq!(2, trigger_names.len());
+        assert_ne!(trigger_names[0], trigger_names[1]);
+        assert!(trigger_names.iter().all(|name| name.len() <= 63));
+
+        // Ensure email change in old schema is propagated to the new column
+        old_db
+            .simple_query("UPDATE users SET email = 'test2@example.com' WHERE id = 1")
+            .unwrap();
+        let email: String = new_db
+            .query(
+                "
+                SELECT primary_contact_email_address
+                FROM organization_membership_profiles
+                WHERE user_id = 1
+                ",
+                &[],
+            )
+            .unwrap()
+            .first()
+            .map(|row| row.get(0))
+            .unwrap();
+        assert_eq!("test2@example.com", email);
+    });
+
+    test.after_completion(|db| {
+        let email: String = db
+            .query(
+                "
+                SELECT primary_contact_email_address
+                FROM organization_membership_profiles
+                WHERE user_id = 1
+                ",
+                &[],
+            )
+            .unwrap()
+            .first()
+            .map(|row| row.get(0))
+            .unwrap();
+        assert_eq!("test2@example.com", email);
+    });
+
+    test.run();
+}

--- a/tests/alter_column.rs
+++ b/tests/alter_column.rs
@@ -1456,3 +1456,74 @@ fn alter_column_with_hash_index() {
 
     test.run();
 }
+
+#[test]
+fn alter_column_with_index_at_max_name_length() {
+    let mut test = Test::new("Alter column with long index name");
+
+    // The index names are as long as Postgres allows and only differ at the very end,
+    // so prefixing them while they are swapped for the temporary indices would push
+    // them past the limit and make them collide
+    test.first_migration(
+        r#"
+        name = "create_user_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "first_name"
+            type = "TEXT"
+
+            [[actions.columns]]
+            name = "last_name"
+            type = "TEXT"
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_first_name_last_name_covering_index_with_a_long_name_idx1"
+            columns = ["first_name", "last_name"]
+
+        [[actions]]
+        type = "add_index"
+        table = "users"
+
+            [actions.index]
+            name = "users_first_name_last_name_covering_index_with_a_long_name_idx2"
+            columns = ["last_name"]
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "uppercase_last_name"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "last_name"
+        up = "UPPER(last_name)"
+        down = "LOWER(last_name)"
+        "#,
+    );
+
+    test.after_completion(|db| {
+        let definitions = index_definitions(
+            db,
+            "users_first_name_last_name_covering_index_with_a_long_name_idx_",
+        );
+        assert_eq!(2, definitions.len(), "expected both indices to still exist");
+        assert!(index_definitions(db, "__reshape%").is_empty());
+    });
+
+    test.run();
+}

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -451,3 +451,114 @@ fn remove_column_with_complex_down() {
 
     test.run();
 }
+
+#[test]
+fn remove_column_with_long_names() {
+    let mut test = Test::new("Remove column with long names");
+
+    // The table and column names are long enough that the generated names would exceed
+    // Postgres' limit of 63 characters on identifiers, which used to make the forward,
+    // reverse and NOT NULL triggers collapse into the same name
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "organization_membership_profiles"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "primary_contact_email_address"
+            type = "TEXT"
+            nullable = false
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["user_id"]
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "remove_email"
+
+        [[actions]]
+        type = "remove_column"
+        table = "organization_membership_profiles"
+        column = "primary_contact_email_address"
+
+            [actions.down]
+            table = "profiles"
+            value = "profiles.email"
+            where = "organization_membership_profiles.id = profiles.user_id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query(
+            "INSERT INTO organization_membership_profiles (id, primary_contact_email_address) VALUES (1, 'test@example.com')",
+        )
+        .unwrap();
+        db.simple_query("INSERT INTO profiles (user_id, email) VALUES (1, 'test@example.com')")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // Every generated name should fit within the limit and be distinct
+        let trigger_names: Vec<String> = old_db
+            .query(
+                "SELECT tgname::text FROM pg_trigger WHERE tgname LIKE '__reshape%' ORDER BY 1",
+                &[],
+            )
+            .unwrap()
+            .iter()
+            .map(|row| row.get(0))
+            .collect();
+        assert_eq!(3, trigger_names.len());
+        assert_ne!(trigger_names[0], trigger_names[1]);
+        assert_ne!(trigger_names[1], trigger_names[2]);
+        assert!(trigger_names.iter().all(|name| name.len() <= 63));
+
+        new_db
+            .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
+            .unwrap();
+
+        // Ensure new email was propagated to the old schema
+        let email: String = old_db
+            .query(
+                "
+                SELECT primary_contact_email_address
+                FROM organization_membership_profiles
+                WHERE id = 1
+                ",
+                &[],
+            )
+            .unwrap()
+            .first()
+            .map(|row| row.get(0))
+            .unwrap();
+        assert_eq!("test2@example.com", email);
+
+        // The NOT NULL check should still be enforced for the old schema
+        let result = old_db.simple_query(
+            "INSERT INTO organization_membership_profiles (id, primary_contact_email_address) VALUES (2, NULL)",
+        );
+        assert!(result.is_err(), "expected NULL insert to be rejected");
+    });
+
+    test.run();
+}


### PR DESCRIPTION
## Problem

Names generated for triggers, temporary columns and constraints embed the user's table and column names verbatim, e.g. `__reshape_0001_0000_add_column_{table}_{column}_rev`. Postgres silently truncates identifiers to 63 bytes, and reshape never checked the length. Two things went wrong once a table plus column name reached roughly 30 characters:

- **Trigger collision.** The forward and reverse triggers of `add_column` and `remove_column` differ only by a trailing `_rev` / `_nn`. Truncation dropped the suffix, so `CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS` silently replaced the forward trigger with the reverse one. Old-schema writes stopped propagating, with no error.
- **Broken new-schema view.** The temporary column name was truncated in the database but the alias map in `schema.rs` used the full name, so the view exposed the raw temporary column and the added column was missing (`column "..." does not exist`).

## Fix

- `common::bounded_identifier(head, body, tail)` builds `{head}{body}{tail}` and, only when it would exceed 63 bytes, keeps `head` and `tail` intact and cuts `body` down with an 8-hex-char FNV-1a hash of the full name in its place. Names which already fit are unchanged, so in-progress migrations are unaffected. FNV is implemented inline (a few lines) since the standard hasher isn't guaranteed stable across versions and the names are recomputed in `run`, `complete` and `abort`.
- `MigrationContext::name(kind, parts, suffix)` wraps this for action-generated names. All names embedding user input in `add_column`, `remove_column`, `alter_column` and `create_table` go through it.
- The `__reshape_old_` index prefix in `alter_column::complete` is bounded the same way. Since a hashed name can't be reversed back to the original, the swap of old and temporary index now happens atomically in one `batch_execute`, and an index already carrying the prefix on retry is only dropped. This also fixes the retry path trimming `__reshape_old` without its trailing underscore, which produced `__reshape_old__name`.
- The `migration_{name}` schema name and the final `{table}_{column}_not_null` constraint name are bounded too.

## Tests

- Unit tests for `bounded_identifier`.
- `add_column_with_long_names` and `remove_column_with_long_names` reproduce the trigger collision and fail on `main`.
- `alter_column_with_index_at_max_name_length` covers the reworked index swap with two 63-char index names. Note this one passes on `main` as well, since Postgres truncated consistently there; it guards the new path rather than reproducing a bug.

`cargo test -- --test-threads=1` and `cargo clippy --all-targets -- -D warnings` pass.