### PR TITLE
Truncate schema names like Postgres instead of hashing them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,10 @@ pub fn schema_query_for_migration(migration_name: &str) -> String {
     format!("SET search_path TO {}", schema_name)
 }
 
+// Truncated like Postgres would, so that the name matches what `current_setting('search_path')`
+// returns once an application has set it
 pub(crate) fn schema_name_for_migration(migration_name: &str) -> String {
-    migrations::common::bounded_identifier("migration_", migration_name, "")
+    migrations::common::truncate_identifier(&format!("migration_{}", migration_name))
 }
 
 fn migrate(

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -533,6 +533,16 @@ pub fn bounded_identifier(head: &str, body: &str, tail: &str) -> String {
     format!("{head}{}_{hash}{tail}", &body[..cut])
 }
 
+/// Cuts an identifier down to Postgres' limit the same way Postgres does, so that a name
+/// built by reshape matches what Postgres reports back, for example in `search_path`.
+pub fn truncate_identifier(name: &str) -> String {
+    let mut cut = MAX_IDENTIFIER_LENGTH.min(name.len());
+    while !name.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    name[..cut].to_string()
+}
+
 // 64-bit FNV-1a. Names are recomputed on every run, so the hash has to be stable
 // across processes and versions, which rules out the standard library's hasher.
 fn fnv1a_hash(input: &str) -> u64 {
@@ -587,6 +597,19 @@ mod tests {
             "",
         );
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn truncate_identifier_cuts_at_the_limit() {
+        assert_eq!("migration_short", truncate_identifier("migration_short"));
+
+        let long = format!("migration_{}", "a".repeat(60));
+        assert_eq!(&long[..63], truncate_identifier(&long));
+
+        let multibyte = format!("migration_{}", "ä".repeat(30));
+        let truncated = truncate_identifier(&multibyte);
+        assert_eq!(62, truncated.len());
+        assert!(multibyte.starts_with(&truncated));
     }
 
     #[test]

--- a/tests/add_column.rs
+++ b/tests/add_column.rs
@@ -1205,3 +1205,74 @@ fn add_column_with_long_names() {
 
     test.run();
 }
+
+#[test]
+fn add_column_in_migration_with_long_name() {
+    let mut test = Test::new("Add column in migration with long name");
+
+    test.first_migration(
+        r#"
+        name = "create_users_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "name"
+            type = "TEXT"
+        "#,
+    );
+
+    // The migration name pushes the schema name past Postgres' limit of 63 characters
+    test.second_migration(
+        r#"
+        name = "add_a_display_name_column_to_users_with_a_migration_name_that_is_too_long"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+        up = "name"
+
+            [actions.column]
+            name = "display_name"
+            type = "TEXT"
+        "#,
+    );
+
+    test.intermediate(|_old_db, new_db| {
+        // The schema name reshape uses should be the one Postgres ended up with
+        let schema: String = new_db
+            .query("SELECT current_schema()::text", &[])
+            .unwrap()
+            .first()
+            .map(|row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            "migration_add_a_display_name_column_to_users_with_a_migration_n",
+            schema
+        );
+
+        // Writes through the new schema must be recognized as such, otherwise the
+        // trigger would overwrite the explicitly set value
+        new_db
+            .simple_query(
+                "INSERT INTO users (id, name, display_name) VALUES (1, 'test', 'explicit')",
+            )
+            .unwrap();
+        let display_name: String = new_db
+            .query("SELECT display_name FROM users WHERE id = 1", &[])
+            .unwrap()
+            .first()
+            .map(|row| row.get(0))
+            .unwrap();
+        assert_eq!("explicit", display_name);
+    });
+
+    test.run();
+}


### PR DESCRIPTION
Follow-up to #60. Migration schema names (`migration_{name}`) no longer go through the hashing scheme. They are cut down to 63 bytes exactly the way Postgres does it, so a long migration name keeps its first 53 characters instead of 44 characters plus a hash.

Reshape still truncates on its side rather than passing the full name through. Postgres cuts the `search_path` entry at SET time, so `reshape.is_new_schema()` has to compare `current_setting('search_path')` against the truncated name. Before #60 it compared against the full name and always returned false for migration names over 53 characters, which made new-schema writes run the old-schema triggers.

No collision check between migration names is added, as agreed: migrations are usually prefixed and only two schemas exist at a time.

- `common::truncate_identifier` with a unit test, including a multibyte case
- `add_column_in_migration_with_long_name` checks that the schema reshape names is the one Postgres created, and that a write through the new schema is recognized as such

`cargo test -- --test-threads=1` and `cargo clippy --all-targets -- -D warnings` pass.