### PR TITLE
Fix lost NOT NULL across in-flight columns and make remove_column abort safe

### DIFF
--- a/src/docs/actions/remove-column.md
+++ b/src/docs/actions/remove-column.md
@@ -79,6 +79,8 @@ column = "customer_name"
    - Old schema can still read/write the column
    - New schema doesn't see the column
    - `down` transformation populates values for old schema writes
+   - With a cross-table `down`, writes to `down.table` in the new schema populate the
+     column for the matching rows
 
 3. **Complete phase**:
    - Drops the column
@@ -89,7 +91,11 @@ column = "customer_name"
 
 - The column is only removed during the complete phase
 - If the column is NOT NULL and you need backward compatibility, provide a `down` expression
-- For non-nullable columns with complex `down`, the NOT NULL constraint is temporarily converted to a trigger
+- For non-nullable columns with a cross-table `down`, the NOT NULL constraint is temporarily
+  replaced by triggers. Writes in the old schema are still rejected immediately. In the new
+  schema, the column may be left empty within a transaction, so that a row can be inserted
+  before the row in `down.table` it takes its value from, but the transaction fails at
+  commit if it is still empty. This requires the table to have a primary key
 - In a cross-table `down`, every column in `value` and `where` must be qualified with its
   table name, as the expressions run in triggers on both tables
 - Data in the column is permanently lost after completion

--- a/src/docs/actions/remove-column.md
+++ b/src/docs/actions/remove-column.md
@@ -91,11 +91,7 @@ column = "customer_name"
 
 - The column is only removed during the complete phase
 - If the column is NOT NULL and you need backward compatibility, provide a `down` expression
-- For non-nullable columns with a cross-table `down`, the NOT NULL constraint is temporarily
-  replaced by triggers. Writes in the old schema are still rejected immediately. In the new
-  schema, the column may be left empty within a transaction, so that a row can be inserted
-  before the row in `down.table` it takes its value from, but the transaction fails at
-  commit if it is still empty. This requires the table to have a primary key
+- For non-nullable columns with complex `down`, the NOT NULL constraint is temporarily converted to a trigger
 - In a cross-table `down`, every column in `value` and `where` must be qualified with its
   table name, as the expressions run in triggers on both tables
 - Data in the column is permanently lost after completion

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -214,7 +214,7 @@ impl Action for AddColumn {
                     RETURNS TRIGGER AS $$
                     #variable_conflict use_variable
                     BEGIN
-                        IF NOT reshape.is_new_schema() AND NOT current_setting('reshape.disable_triggers', TRUE) = 'TRUE' THEN
+                        IF NOT reshape.is_new_schema() AND current_setting('reshape.disable_triggers', TRUE) IS DISTINCT FROM 'TRUE' THEN
                             DECLARE
                                 {changed_table} record;
                                 __from_row record;

--- a/src/migrations/add_column.rs
+++ b/src/migrations/add_column.rs
@@ -300,8 +300,16 @@ impl Action for AddColumn {
             .run(&query)
             .context("failed to drop up trigger")?;
 
-        // Update column to be NOT NULL if necessary
-        if !self.column.nullable {
+        // Update column to be NOT NULL if necessary. A later action removing the column
+        // drops the temporary constraint, in which case the column is about to be
+        // dropped as well and is left nullable.
+        let has_not_null_constraint = !self.column.nullable
+            && common::check_constraint_exists(
+                &mut transaction,
+                &self.table,
+                &self.not_null_constraint_name(ctx),
+            )?;
+        if has_not_null_constraint {
             // Validate the temporary constraint (should always be valid).
             // This performs a sequential scan but does not take an exclusive lock.
             let query = format!(
@@ -370,6 +378,14 @@ impl Action for AddColumn {
         schema.change_table(&self.table, |table_changes| {
             table_changes.change_column(&self.column.name, |column_changes| {
                 column_changes.set_column(&self.temp_column_name(ctx));
+
+                // The temporary column is nullable until the migration completes, so
+                // later actions must go by the declared column rather than the physical one
+                column_changes.set_data_type(&self.column.data_type);
+                column_changes.set_nullable(self.column.nullable);
+                if let Some(default) = &self.column.default {
+                    column_changes.set_default(default);
+                }
             })
         });
     }

--- a/src/migrations/alter_column.rs
+++ b/src/migrations/alter_column.rs
@@ -448,6 +448,19 @@ impl Action for AlterColumn {
             table_changes.change_column(&self.column, |column_changes| {
                 column_changes.set_column(&self.temporary_column_name(ctx));
 
+                // Record what the action declares about the column. The temporary column
+                // is nullable until the migration completes regardless of the declared
+                // nullability, so later actions can't go by its physical attributes.
+                if let Some(data_type) = &self.changes.data_type {
+                    column_changes.set_data_type(data_type);
+                }
+                if let Some(nullable) = self.changes.nullable {
+                    column_changes.set_nullable(nullable);
+                }
+                if let Some(default) = &self.changes.default {
+                    column_changes.set_default(default);
+                }
+
                 // The new schema should expose the column under its new name, if renamed.
                 // Note that `up` and `down` still reference the column by its old name as
                 // they operate on the actual columns, not the schema representation.

--- a/src/migrations/common.rs
+++ b/src/migrations/common.rs
@@ -155,32 +155,16 @@ pub fn batch_touch_rows(
 
     let mut cursor: Option<PostgresRawValue> = None;
 
+    let primary_key = get_primary_key_columns_for_table(db, table)?;
+
+    // If no column to touch is passed, we default to the first primary key column (just to make some "update")
+    let touched_column = column.unwrap_or(primary_key[0].as_str());
+
+    let primary_key_columns = primary_key.join(", ");
+    let primary_key_where = primary_key_match(table, &primary_key, "rows");
+
     loop {
         let mut params: Vec<&(dyn ToSql + Sync)> = Vec::new();
-
-        let primary_key = get_primary_key_columns_for_table(db, table)?;
-
-        // If no column to touch is passed, we default to the first primary key column (just to make some "update")
-        let touched_column = match column {
-            Some(column) => column,
-            None => primary_key.first().unwrap(),
-        };
-
-        let primary_key_columns = primary_key.join(", ");
-
-        let primary_key_where = primary_key
-            .iter()
-            .map(|column| {
-                format!(
-                    r#"
-                    "{table}"."{column}" = rows."{column}"
-                    "#,
-                    table = table,
-                    column = column,
-                )
-            })
-            .collect::<Vec<String>>()
-            .join(" AND ");
 
         let returning_columns = primary_key
             .iter()
@@ -235,7 +219,10 @@ pub fn batch_touch_rows(
     Ok(())
 }
 
-fn get_primary_key_columns_for_table(
+/// The columns of a table's primary key, in key order. Fails if the table has no primary
+/// key, which is needed to identify individual rows when backfilling and when checking
+/// rows at the end of a transaction.
+pub fn get_primary_key_columns_for_table(
     db: &mut dyn Conn,
     table: &str,
 ) -> anyhow::Result<Vec<String>> {
@@ -246,16 +233,35 @@ fn get_primary_key_columns_for_table(
             SELECT a.attname AS column_name
             FROM   pg_index i
             JOIN   pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-            WHERE  i.indrelid = '{table}'::regclass
-            AND    i.indisprimary;
+            WHERE  i.indrelid = 'public.\"{table}\"'::regclass
+            AND    i.indisprimary
+            ORDER BY array_position(i.indkey::int2[], a.attnum);
             ",
             table = table
-        ))?
+        ))
+        .context("failed to get primary key columns")?
         .iter()
         .map(|row| row.get("column_name"))
         .collect();
 
+    if primary_key_columns.is_empty() {
+        return Err(anyhow!(
+            "table \"{}\" has no primary key, which is required to identify its rows",
+            table
+        ));
+    }
+
     Ok(primary_key_columns)
+}
+
+/// A condition matching a row of `table` against the row `other`, such as a CTE or a
+/// trigger's `NEW`, on every primary key column
+pub fn primary_key_match(table: &str, primary_key: &[String], other: &str) -> String {
+    primary_key
+        .iter()
+        .map(|column| format!("\"{table}\".\"{column}\" = {other}.\"{column}\""))
+        .collect::<Vec<String>>()
+        .join(" AND ")
 }
 
 pub struct Index {

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -38,6 +38,10 @@ impl RemoveColumn {
         ctx.name("remove_column", &[&self.table, &self.column], "_nn")
     }
 
+    fn not_null_deferred_trigger_name(&self, ctx: &MigrationContext) -> String {
+        ctx.name("remove_column", &[&self.table, &self.column], "_nnd")
+    }
+
     fn not_null_constraint_name(&self, ctx: &MigrationContext) -> String {
         ctx.name("add_column_not_null", &[&self.table, &self.column], "")
     }
@@ -172,38 +176,69 @@ impl Action for RemoveColumn {
                         .first()
                         .ok_or_else(|| anyhow!("no column backing {} exists", self.column))?;
 
-                    // Replace NOT NULL constraint with a constraint trigger that only triggers on the old schema.
-                    // We will add a null check to the down function on the new schema below as well to cover both cases.
-                    // As we are using a complex down function, we must remove the NOT NULL check for the new schema.
-                    // NOT NULL is not checked at the end of a transaction, but immediately upon update.
+                    // NOT NULL is replaced by two triggers, as NOT NULL itself can't be deferred
+                    // and the new schema must be allowed to leave the column empty within a
+                    // transaction, for example when a row is inserted before the row it takes
+                    // its value from. Writes in the old schema keep failing immediately. Writes
+                    // in the new schema are checked when the transaction commits, so no NULL
+                    // can ever be committed and NOT NULL can always be reinstated on abort.
+                    //
+                    // Both triggers use WHEN conditions so that no event is queued for rows
+                    // which don't need checking. A deferred trigger is handed the row as it
+                    // was when the event was queued, so the deferred check looks the row up
+                    // again by primary key to see its value at commit.
+                    let primary_key =
+                        common::get_primary_key_columns_for_table(db, &table.real_name)?;
                     let query = format!(
                         r#"
-                        CREATE OR REPLACE FUNCTION {trigger_name}()
+                        CREATE OR REPLACE FUNCTION {immediate_trigger}()
                         RETURNS TRIGGER AS $$
                         BEGIN
-                            IF NOT reshape.is_new_schema() THEN
-                                IF NEW.{column} IS NULL THEN
-                                    RAISE EXCEPTION '{column} can not be null';
-                                END IF;
-                            END IF;
-                            RETURN NEW;
+                            RAISE EXCEPTION '{column} can not be null' USING ERRCODE = 'not_null_violation';
+                            RETURN NULL;
                         END
                         $$ language 'plpgsql';
 
-                        DROP TRIGGER IF EXISTS "{trigger_name}" ON "{table}";
-
-                        CREATE CONSTRAINT TRIGGER "{trigger_name}"
+                        DROP TRIGGER IF EXISTS "{immediate_trigger}" ON "{table}";
+                        CREATE CONSTRAINT TRIGGER "{immediate_trigger}"
                             AFTER INSERT OR UPDATE
                             ON "{table}"
                             FOR EACH ROW
-                            EXECUTE PROCEDURE {trigger_name}();
+                            WHEN (NOT reshape.is_new_schema() AND NEW."{column}" IS NULL)
+                            EXECUTE PROCEDURE {immediate_trigger}();
+
+                        CREATE OR REPLACE FUNCTION {deferred_trigger}()
+                        RETURNS TRIGGER AS $$
+                        BEGIN
+                            PERFORM 1
+                            FROM public."{table}"
+                            WHERE {primary_key_match} AND "{table}"."{column}" IS NULL;
+
+                            IF FOUND THEN
+                                RAISE EXCEPTION '{column} can not be null' USING ERRCODE = 'not_null_violation';
+                            END IF;
+                            RETURN NULL;
+                        END
+                        $$ language 'plpgsql';
+
+                        DROP TRIGGER IF EXISTS "{deferred_trigger}" ON "{table}";
+                        CREATE CONSTRAINT TRIGGER "{deferred_trigger}"
+                            AFTER INSERT OR UPDATE
+                            ON "{table}"
+                            DEFERRABLE INITIALLY DEFERRED
+                            FOR EACH ROW
+                            WHEN (reshape.is_new_schema() AND NEW."{column}" IS NULL)
+                            EXECUTE PROCEDURE {deferred_trigger}();
                         "#,
                         table = table.real_name,
-                        trigger_name = self.not_null_constraint_trigger_name(ctx),
+                        immediate_trigger = self.not_null_constraint_trigger_name(ctx),
+                        deferred_trigger = self.not_null_deferred_trigger_name(ctx),
                         column = old_schema_column,
+                        primary_key_match =
+                            common::primary_key_match(&table.real_name, &primary_key, "NEW"),
                     );
                     db.run(&query)
-                        .context("failed to create null constraint trigger")?;
+                        .context("failed to create NOT NULL triggers")?;
 
                     for backing_column in &backing_columns {
                         db.run(&format!(
@@ -241,7 +276,7 @@ impl Action for RemoveColumn {
                     format!(
                         r#"
                         IF {value} IS NULL THEN
-                            RAISE EXCEPTION '{column_name} can not be null';
+                            RAISE EXCEPTION '{column_name} can not be null' USING ERRCODE = 'not_null_violation';
                         END IF;
                         "#,
                         column_name = self.column,
@@ -307,7 +342,7 @@ impl Action for RemoveColumn {
                     RETURNS TRIGGER AS $$
                     #variable_conflict use_variable
                     BEGIN
-                        IF reshape.is_new_schema() AND NOT current_setting('reshape.disable_triggers', TRUE) = 'TRUE' THEN
+                        IF reshape.is_new_schema() AND current_setting('reshape.disable_triggers', TRUE) IS DISTINCT FROM 'TRUE' THEN
                             DECLARE
                                 {changed_table} record;
                                 __from_row record;
@@ -368,21 +403,25 @@ impl Action for RemoveColumn {
             .context("failed to drop index")?;
         }
 
-        // Remove column, function and trigger
+        // Remove triggers, functions and column. The triggers go first as the NOT NULL
+        // triggers reference the column in their WHEN conditions, which prevents it
+        // from being dropped while they exist.
         let query = format!(
             r#"
-            ALTER TABLE "{table}"
-            DROP COLUMN IF EXISTS "{column}";
-
             DROP FUNCTION IF EXISTS "{trigger_name}" CASCADE;
             DROP FUNCTION IF EXISTS "{reverse_trigger_name}" CASCADE;
             DROP FUNCTION IF EXISTS "{null_trigger_name}" CASCADE;
+            DROP FUNCTION IF EXISTS "{deferred_null_trigger_name}" CASCADE;
+
+            ALTER TABLE "{table}"
+            DROP COLUMN IF EXISTS "{column}";
             "#,
             table = self.table,
             column = self.column,
             trigger_name = self.trigger_name(ctx),
             reverse_trigger_name = self.reverse_trigger_name(ctx),
             null_trigger_name = self.not_null_constraint_trigger_name(ctx),
+            deferred_null_trigger_name = self.not_null_deferred_trigger_name(ctx),
         );
         db.run(&query)
             .context("failed to drop column and down trigger")?;
@@ -416,19 +455,26 @@ impl Action for RemoveColumn {
         // The column doesn't exist if it was added earlier in the same migration. Aborting
         // that action removes its temporary column, so there is nothing to reinstate.
         if has_not_null_function && self.column_exists(db)? {
-            // Make column NOT NULL again without taking any long lived locks with a temporary constraint
-            let query = format!(
-                r#"
-                 ALTER TABLE "{table}"
-                 ADD CONSTRAINT "{constraint_name}"
-                 CHECK ("{column}" IS NOT NULL) NOT VALID
-                 "#,
-                table = self.table,
-                constraint_name = self.not_null_constraint_name(ctx),
-                column = self.column,
-            );
-            db.run(&query)
-                .context("failed to add NOT NULL constraint")?;
+            // Make column NOT NULL again without taking any long lived locks with a temporary
+            // constraint. The constraint already exists if an earlier abort was interrupted.
+            if !common::check_constraint_exists(
+                db,
+                &self.table,
+                &self.not_null_constraint_name(ctx),
+            )? {
+                let query = format!(
+                    r#"
+                    ALTER TABLE "{table}"
+                    ADD CONSTRAINT "{constraint_name}"
+                    CHECK ("{column}" IS NOT NULL) NOT VALID
+                    "#,
+                    table = self.table,
+                    constraint_name = self.not_null_constraint_name(ctx),
+                    column = self.column,
+                );
+                db.run(&query)
+                    .context("failed to add NOT NULL constraint")?;
+            }
 
             let query = format!(
                 r#"
@@ -457,7 +503,7 @@ impl Action for RemoveColumn {
             let query = format!(
                 r#"
                 ALTER TABLE "{table}"
-                DROP CONSTRAINT "{constraint_name}"
+                DROP CONSTRAINT IF EXISTS "{constraint_name}"
                 "#,
                 table = self.table,
                 constraint_name = self.not_null_constraint_name(ctx),
@@ -472,10 +518,12 @@ impl Action for RemoveColumn {
             DROP FUNCTION IF EXISTS "{trigger_name}" CASCADE;
             DROP FUNCTION IF EXISTS "{reverse_trigger_name}" CASCADE;
             DROP FUNCTION IF EXISTS "{null_trigger_name}" CASCADE;
+            DROP FUNCTION IF EXISTS "{deferred_null_trigger_name}" CASCADE;
             "#,
             trigger_name = self.trigger_name(ctx),
             reverse_trigger_name = self.reverse_trigger_name(ctx),
             null_trigger_name = self.not_null_constraint_trigger_name(ctx),
+            deferred_null_trigger_name = self.not_null_deferred_trigger_name(ctx),
         ))
         .context("failed to drop down trigger")?;
 

--- a/src/migrations/remove_column.rs
+++ b/src/migrations/remove_column.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RemoveColumn {
@@ -39,6 +40,50 @@ impl RemoveColumn {
 
     fn not_null_constraint_name(&self, ctx: &MigrationContext) -> String {
         ctx.name("add_column_not_null", &[&self.table, &self.column], "")
+    }
+
+    /// The real columns backing the column which exist in the database, oldest first.
+    /// A column added earlier in the migration only exists as its temporary column.
+    fn existing_backing_columns(
+        &self,
+        db: &mut dyn Conn,
+        schema: &Schema,
+        real_table: &str,
+    ) -> anyhow::Result<Vec<String>> {
+        let existing: HashSet<String> = db
+            .query_with_params(
+                "
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = $1
+                ",
+                &[&real_table],
+            )
+            .context("failed to get columns")?
+            .iter()
+            .map(|row| row.get("column_name"))
+            .collect();
+
+        Ok(schema
+            .backing_columns(&self.table, &self.column)
+            .into_iter()
+            .filter(|column| existing.contains(column))
+            .collect())
+    }
+
+    fn column_exists(&self, db: &mut dyn Conn) -> anyhow::Result<bool> {
+        let rows = db
+            .query_with_params(
+                "
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2
+                ",
+                &[&self.table, &self.column],
+            )
+            .context("failed to check whether column exists")?;
+
+        Ok(!rows.is_empty())
     }
 }
 
@@ -115,6 +160,18 @@ impl Action for RemoveColumn {
                 let from_table = schema.get_table(db, from_table)?;
 
                 let maybe_null_check = if !column.nullable {
+                    // The column may be backed by temporary columns introduced by earlier
+                    // actions in the migration, in which case writes propagate through the
+                    // whole chain of columns. Each of them enforces NOT NULL, either directly
+                    // or through a temporary check constraint, so all of them have to be
+                    // lifted for the new schema to be able to leave the removed column empty.
+                    // The oldest column is the one the old schema writes.
+                    let backing_columns =
+                        self.existing_backing_columns(db, schema, &table.real_name)?;
+                    let old_schema_column = backing_columns
+                        .first()
+                        .ok_or_else(|| anyhow!("no column backing {} exists", self.column))?;
+
                     // Replace NOT NULL constraint with a constraint trigger that only triggers on the old schema.
                     // We will add a null check to the down function on the new schema below as well to cover both cases.
                     // As we are using a complex down function, we must remove the NOT NULL check for the new schema.
@@ -141,23 +198,45 @@ impl Action for RemoveColumn {
                             FOR EACH ROW
                             EXECUTE PROCEDURE {trigger_name}();
                         "#,
-                        table = self.table,
+                        table = table.real_name,
                         trigger_name = self.not_null_constraint_trigger_name(ctx),
-                        column = self.column,
+                        column = old_schema_column,
                     );
                     db.run(&query)
                         .context("failed to create null constraint trigger")?;
 
-                    db.run(&format!(
-                        r#"
-                        ALTER TABLE {table}
-                        ALTER COLUMN {column}
-                        DROP NOT NULL
-                        "#,
-                        table = self.table,
-                        column = self.column
-                    ))
-                    .context("failed to remove column not null constraint")?;
+                    for backing_column in &backing_columns {
+                        db.run(&format!(
+                            r#"
+                            ALTER TABLE "{table}"
+                            ALTER COLUMN "{column}"
+                            DROP NOT NULL
+                            "#,
+                            table = table.real_name,
+                            column = backing_column,
+                        ))
+                        .context("failed to remove column not null constraint")?;
+
+                        let checks = common::get_check_constraints_for_column(
+                            db,
+                            &table.real_name,
+                            backing_column,
+                        )?;
+                        for check in checks
+                            .iter()
+                            .filter(|check| common::is_temporary_not_null_constraint(&check.name))
+                        {
+                            db.run(&format!(
+                                r#"
+                                ALTER TABLE "{table}"
+                                DROP CONSTRAINT IF EXISTS "{constraint_name}"
+                                "#,
+                                table = table.real_name,
+                                constraint_name = check.name,
+                            ))
+                            .context("failed to remove temporary NOT NULL constraint")?;
+                        }
+                    }
 
                     format!(
                         r#"
@@ -334,7 +413,9 @@ impl Action for RemoveColumn {
             .context("failed to get any NOT NULL function")?
             .is_empty();
 
-        if has_not_null_function {
+        // The column doesn't exist if it was added earlier in the same migration. Aborting
+        // that action removes its temporary column, so there is nothing to reinstate.
+        if has_not_null_function && self.column_exists(db)? {
             // Make column NOT NULL again without taking any long lived locks with a temporary constraint
             let query = format!(
                 r#"

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -16,8 +16,11 @@ use std::collections::{HashMap, HashSet};
 // the corresponding `TableChanges`. The possible changes are:
 //   - Changing the name which updates `current_name`.
 //   - Changing the backing column which will add the new column to the end of
-//     `intermediate_columns`. This is used when temporary columns are
+//     `backing_columns`. This is used when temporary columns are
 //     introduced which will eventually replace the current column.
+//   - Declaring the type, nullability or default, which are recorded so that they
+//     take precedence over the physical attributes of the backing column. This
+//     matters as temporary columns are nullable until the migration completes.
 //   - Removing which sets the `removed` flag.
 //
 // Schema provides some schema introspection methods, `get_tables` and `get_table`,
@@ -50,6 +53,24 @@ impl Schema {
 
         let table_changes = &mut self.table_changes[table_change_index];
         f(table_changes)
+    }
+
+    /// The real columns which back a column, oldest first. The last one is the column
+    /// currently backing it. The earlier ones have been replaced by temporary columns
+    /// but remain in the table, and continue to be written, until the migration
+    /// completes.
+    pub fn backing_columns(&self, table_name: &str, column_name: &str) -> Vec<String> {
+        self.table_changes
+            .iter()
+            .find(|changes| changes.current_name == table_name)
+            .and_then(|changes| {
+                changes
+                    .column_changes
+                    .iter()
+                    .find(|column| column.current_name == column_name)
+            })
+            .map(|column| column.backing_columns.clone())
+            .unwrap_or_else(|| vec![column_name.to_string()])
     }
 
     /// Whether a check constraint on a table is removed by an earlier action of the
@@ -130,6 +151,9 @@ pub struct ColumnChanges {
     current_name: String,
     backing_columns: Vec<String>,
     removed: bool,
+    data_type: Option<String>,
+    nullable: Option<bool>,
+    default: Option<String>,
 }
 
 impl ColumnChanges {
@@ -138,6 +162,9 @@ impl ColumnChanges {
             current_name: name.to_string(),
             backing_columns: vec![name],
             removed: false,
+            data_type: None,
+            nullable: None,
+            default: None,
         }
     }
 
@@ -149,6 +176,18 @@ impl ColumnChanges {
         self.backing_columns.push(column_name.to_string())
     }
 
+    pub fn set_data_type(&mut self, data_type: &str) {
+        self.data_type = Some(data_type.to_string());
+    }
+
+    pub fn set_nullable(&mut self, nullable: bool) {
+        self.nullable = Some(nullable);
+    }
+
+    pub fn set_default(&mut self, default: &str) {
+        self.default = Some(default.to_string());
+    }
+
     pub fn set_removed(&mut self) {
         self.removed = true;
     }
@@ -158,6 +197,46 @@ impl ColumnChanges {
             .last()
             .expect("backing_columns should never be empty")
     }
+
+    /// The column as the schema sees it, given the physical column currently backing it.
+    ///
+    /// Attributes declared by an action take precedence. Anything not declared is
+    /// inherited from the column the chain of backing columns started from, as a
+    /// temporary column is nullable until the migration completes no matter what the
+    /// column is declared as. A column added in this migration has no such original
+    /// column and its temporary column is used instead.
+    fn resolve(
+        &self,
+        current: &PhysicalColumn,
+        physical: &HashMap<&str, &PhysicalColumn>,
+    ) -> Column {
+        let original = self
+            .backing_columns
+            .first()
+            .and_then(|name| physical.get(name.as_str()))
+            .copied()
+            .unwrap_or(current);
+
+        Column {
+            name: self.current_name.clone(),
+            real_name: current.name.clone(),
+            data_type: self
+                .data_type
+                .clone()
+                .unwrap_or_else(|| original.data_type.clone()),
+            nullable: self.nullable.unwrap_or(original.nullable),
+            default: self.default.clone().or_else(|| original.default.clone()),
+        }
+    }
+}
+
+/// A column as it exists in the database
+#[derive(Debug)]
+struct PhysicalColumn {
+    name: String,
+    data_type: String,
+    nullable: bool,
+    default: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -267,10 +346,10 @@ impl Schema {
             .iter()
             .find(|changes| changes.real_name == real_table_name);
 
-        let real_columns: Vec<(String, String, bool, Option<String>)> = db
+        let real_columns: Vec<PhysicalColumn> = db
             .query(&format!(
                 "
-                SELECT column_name, CASE WHEN data_type = 'USER-DEFINED' THEN udt_name ELSE data_type END, is_nullable, column_default
+                SELECT column_name, CASE WHEN data_type = 'USER-DEFINED' THEN udt_name ELSE data_type END AS data_type, is_nullable, column_default
                 FROM information_schema.columns
                 WHERE table_name = '{table}' AND table_schema = 'public'
                 ORDER BY ordinal_position
@@ -278,28 +357,30 @@ impl Schema {
                 table = real_table_name,
             ))?
             .iter()
-            .map(|row| {
-                (
-                    row.get("column_name"),
-                    row.get("data_type"),
-                    row.get::<'_, _, String>("is_nullable") == "YES",
-                    row.get("column_default"),
-                )
+            .map(|row| PhysicalColumn {
+                name: row.get("column_name"),
+                data_type: row.get("data_type"),
+                nullable: row.get::<'_, _, String>("is_nullable") == "YES",
+                default: row.get("column_default"),
             })
             .collect();
 
+        // Changed columns inherit attributes from the column they originally replaced,
+        // which is looked up by name
+        let physical: HashMap<&str, &PhysicalColumn> = real_columns
+            .iter()
+            .map(|column| (column.name.as_str(), column))
+            .collect();
+
         let mut ignore_columns: HashSet<String> = HashSet::new();
-        let mut aliases: HashMap<String, &str> = HashMap::new();
+        let mut changed_columns: HashMap<String, &ColumnChanges> = HashMap::new();
 
         if let Some(changes) = table_changes {
             for column_changes in &changes.column_changes {
                 if column_changes.removed {
                     ignore_columns.insert(column_changes.real_name().to_string());
                 } else {
-                    aliases.insert(
-                        column_changes.real_name().to_string(),
-                        &column_changes.current_name,
-                    );
+                    changed_columns.insert(column_changes.real_name().to_string(), column_changes);
                 }
 
                 let (_, rest) = column_changes
@@ -315,23 +396,23 @@ impl Schema {
 
         let mut columns: Vec<Column> = Vec::new();
 
-        for (real_name, data_type, nullable, default) in real_columns {
-            if ignore_columns.contains(&*real_name) {
+        for column in &real_columns {
+            if ignore_columns.contains(&column.name) {
                 continue;
             }
 
-            let name = aliases
-                .get(&real_name)
-                .map(|alias| alias.to_string())
-                .unwrap_or_else(|| real_name.to_string());
+            let column = match changed_columns.get(&column.name) {
+                Some(changes) => changes.resolve(column, &physical),
+                None => Column {
+                    name: column.name.clone(),
+                    real_name: column.name.clone(),
+                    data_type: column.data_type.clone(),
+                    nullable: column.nullable,
+                    default: column.default.clone(),
+                },
+            };
 
-            columns.push(Column {
-                name,
-                real_name,
-                data_type,
-                nullable,
-                default,
-            });
+            columns.push(column);
         }
 
         let current_table_name = table_changes

--- a/tests/alter_column.rs
+++ b/tests/alter_column.rs
@@ -1674,3 +1674,46 @@ fn alter_column_keeps_not_null_from_in_flight_add_column() {
 
     test.run();
 }
+
+#[test]
+fn alter_column_requires_primary_key() {
+    let mut test = Test::new("Alter column on table without primary key fails");
+
+    test.first_migration(
+        r#"
+        name = "create_user_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    // Backfilling identifies rows by their primary key, so a table without one can't be
+    // altered and should fail with a clear error rather than a crash
+    test.after_first(|db| {
+        db.simple_query("CREATE TABLE public.logs (id INTEGER, message TEXT)")
+            .unwrap();
+    });
+
+    test.second_migration(
+        r#"
+        name = "uppercase_log_messages"
+
+        [[actions]]
+        type = "alter_column"
+        table = "logs"
+        column = "message"
+        up = "UPPER(message)"
+        down = "LOWER(message)"
+        "#,
+    );
+
+    test.expect_failure();
+    test.run();
+}

--- a/tests/alter_column.rs
+++ b/tests/alter_column.rs
@@ -999,6 +999,24 @@ fn alter_column_multiple() {
         assert_eq!(48, result);
     });
 
+    test.after_completion(|db| {
+        // The column must stay NOT NULL. The second action must not inherit the
+        // nullability of the first action's temporary column, which is nullable
+        // until the migration completes.
+        let is_nullable: String = db
+            .query_one(
+                "
+                SELECT is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'counter'
+                ",
+                &[],
+            )
+            .unwrap()
+            .get("is_nullable");
+        assert_eq!("NO", is_nullable);
+    });
+
     test.run();
 }
 
@@ -1523,6 +1541,135 @@ fn alter_column_with_index_at_max_name_length() {
         );
         assert_eq!(2, definitions.len(), "expected both indices to still exist");
         assert!(index_definitions(db, "__reshape%").is_empty());
+    });
+
+    test.run();
+}
+
+#[test]
+fn alter_column_keeps_not_null_from_earlier_in_flight_alter() {
+    let mut test = Test::new("Alter column keeps NOT NULL set by earlier in-flight alter");
+
+    test.first_migration(
+        r#"
+        name = "create_user_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "community_name_visible"
+            type = "BOOLEAN"
+        "#,
+    );
+
+    // The first action makes the column NOT NULL, the second only changes its default.
+    // The second action must not read the physical attributes of the first action's
+    // temporary column, which is nullable until the migration completes.
+    test.second_migration(
+        r#"
+        name = "make_visible_not_null_then_change_default"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "community_name_visible"
+        up = "COALESCE(community_name_visible, false)"
+
+            [actions.changes]
+            nullable = false
+            default = "false"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "community_name_visible"
+
+            [actions.changes]
+            default = "true"
+        "#,
+    );
+
+    test.after_completion(|db| {
+        let row = db
+            .query_one(
+                "
+                SELECT is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'community_name_visible'
+                ",
+                &[],
+            )
+            .unwrap();
+        assert_eq!("NO", row.get::<_, String>("is_nullable"));
+        assert_eq!("true", row.get::<_, String>("column_default"));
+    });
+
+    test.run();
+}
+
+#[test]
+fn alter_column_keeps_not_null_from_in_flight_add_column() {
+    let mut test = Test::new("Alter column keeps NOT NULL set by in-flight add_column");
+
+    test.first_migration(
+        r#"
+        name = "create_user_table"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "add_visible_then_change_default"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+
+            [actions.column]
+            name = "community_name_visible"
+            type = "BOOLEAN"
+            nullable = false
+            default = "false"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "community_name_visible"
+
+            [actions.changes]
+            default = "true"
+        "#,
+    );
+
+    test.after_completion(|db| {
+        let row = db
+            .query_one(
+                "
+                SELECT is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'community_name_visible'
+                ",
+                &[],
+            )
+            .unwrap();
+        assert_eq!("NO", row.get::<_, String>("is_nullable"));
+        assert_eq!("true", row.get::<_, String>("column_default"));
     });
 
     test.run();

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -566,89 +566,6 @@ fn remove_column_with_long_names() {
     test.run();
 }
 
-// Checks for a NOT NULL column removed with a cross-table down, for tests where the
-// column exists in the old schema
-fn check_not_null_column_with_complex_down(old_db: &mut Client, new_db: &mut Client) {
-    // The old schema must still reject NULL in the removed column, immediately
-    let error = old_db
-        .simple_query("INSERT INTO users (id, email) VALUES (2, NULL)")
-        .unwrap_err();
-    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
-
-    // The new schema doesn't have the column. A user without a profile can't be
-    // committed as the column would be left empty for the old schema
-    let error = new_db
-        .simple_query("INSERT INTO users (id) VALUES (3)")
-        .unwrap_err();
-    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
-    let count: i64 = old_db
-        .query_one("SELECT COUNT(*) FROM users WHERE id = 3", &[])
-        .unwrap()
-        .get(0);
-    assert_eq!(0, count);
-
-    // Within a transaction, the user can be inserted before the profile it takes its
-    // email from, as the check is made when the transaction commits
-    new_db
-        .batch_execute(
-            "
-            BEGIN;
-            INSERT INTO users (id) VALUES (4);
-            INSERT INTO profiles (user_id, email) VALUES (4, 'four@example.com');
-            COMMIT;
-            ",
-        )
-        .unwrap();
-    let email: String = old_db
-        .query_one("SELECT email FROM users WHERE id = 4", &[])
-        .unwrap()
-        .get("email");
-    assert_eq!("four@example.com", email);
-
-    // A transaction which leaves the column empty fails when committing
-    let error = new_db
-        .batch_execute(
-            "
-            BEGIN;
-            INSERT INTO users (id) VALUES (5);
-            COMMIT;
-            ",
-        )
-        .unwrap_err();
-    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
-    let count: i64 = old_db
-        .query_one("SELECT COUNT(*) FROM users WHERE id = 5", &[])
-        .unwrap()
-        .get(0);
-    assert_eq!(0, count);
-
-    // Writes to the source table in the new schema fill in the removed column
-    new_db
-        .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
-        .unwrap();
-    let email: String = old_db
-        .query_one("SELECT email FROM users WHERE id = 1", &[])
-        .unwrap()
-        .get("email");
-    assert_eq!("test2@example.com", email);
-}
-
-// Asserts that NOT NULL is back on users.email once the migration has been aborted
-fn assert_email_not_null(db: &mut Client) {
-    let is_nullable: String = db
-        .query_one(
-            "
-            SELECT is_nullable
-            FROM information_schema.columns
-            WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'email'
-            ",
-            &[],
-        )
-        .unwrap()
-        .get("is_nullable");
-    assert_eq!("NO", is_nullable);
-}
-
 #[test]
 fn remove_column_not_null_with_complex_down() {
     let mut test = Test::new("Remove NOT NULL column with complex down");
@@ -884,4 +801,87 @@ fn remove_column_not_null_from_in_flight_add_column_with_complex_down() {
     });
 
     test.run();
+}
+
+// Checks for a NOT NULL column removed with a cross-table down, for tests where the
+// column exists in the old schema
+fn check_not_null_column_with_complex_down(old_db: &mut Client, new_db: &mut Client) {
+    // The old schema must still reject NULL in the removed column, immediately
+    let error = old_db
+        .simple_query("INSERT INTO users (id, email) VALUES (2, NULL)")
+        .unwrap_err();
+    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
+
+    // The new schema doesn't have the column. A user without a profile can't be
+    // committed as the column would be left empty for the old schema
+    let error = new_db
+        .simple_query("INSERT INTO users (id) VALUES (3)")
+        .unwrap_err();
+    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
+    let count: i64 = old_db
+        .query_one("SELECT COUNT(*) FROM users WHERE id = 3", &[])
+        .unwrap()
+        .get(0);
+    assert_eq!(0, count);
+
+    // Within a transaction, the user can be inserted before the profile it takes its
+    // email from, as the check is made when the transaction commits
+    new_db
+        .batch_execute(
+            "
+            BEGIN;
+            INSERT INTO users (id) VALUES (4);
+            INSERT INTO profiles (user_id, email) VALUES (4, 'four@example.com');
+            COMMIT;
+            ",
+        )
+        .unwrap();
+    let email: String = old_db
+        .query_one("SELECT email FROM users WHERE id = 4", &[])
+        .unwrap()
+        .get("email");
+    assert_eq!("four@example.com", email);
+
+    // A transaction which leaves the column empty fails when committing
+    let error = new_db
+        .batch_execute(
+            "
+            BEGIN;
+            INSERT INTO users (id) VALUES (5);
+            COMMIT;
+            ",
+        )
+        .unwrap_err();
+    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
+    let count: i64 = old_db
+        .query_one("SELECT COUNT(*) FROM users WHERE id = 5", &[])
+        .unwrap()
+        .get(0);
+    assert_eq!(0, count);
+
+    // Writes to the source table in the new schema fill in the removed column
+    new_db
+        .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
+        .unwrap();
+    let email: String = old_db
+        .query_one("SELECT email FROM users WHERE id = 1", &[])
+        .unwrap()
+        .get("email");
+    assert_eq!("test2@example.com", email);
+}
+
+// Asserts that NOT NULL is back on users.email once the migration has been aborted
+fn assert_email_not_null(db: &mut Client) {
+    let is_nullable: String = db
+        .query_one(
+            "
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'email'
+            ",
+            &[],
+        )
+        .unwrap()
+        .get("is_nullable");
+    assert_eq!("NO", is_nullable);
 }

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::{assert_invalid, Test};
+use postgres::{error::SqlState, Client};
 
 #[test]
 fn remove_column_invalid_down_sql() {
@@ -528,9 +529,11 @@ fn remove_column_with_long_names() {
             .iter()
             .map(|row| row.get(0))
             .collect();
-        assert_eq!(3, trigger_names.len());
-        assert_ne!(trigger_names[0], trigger_names[1]);
-        assert_ne!(trigger_names[1], trigger_names[2]);
+        // Forward, reverse, immediate NOT NULL and deferred NOT NULL triggers
+        assert_eq!(4, trigger_names.len());
+        let mut unique_names = trigger_names.clone();
+        unique_names.dedup();
+        assert_eq!(trigger_names.len(), unique_names.len());
         assert!(trigger_names.iter().all(|name| name.len() <= 63));
 
         new_db
@@ -561,6 +564,89 @@ fn remove_column_with_long_names() {
     });
 
     test.run();
+}
+
+// Checks for a NOT NULL column removed with a cross-table down, for tests where the
+// column exists in the old schema
+fn check_not_null_column_with_complex_down(old_db: &mut Client, new_db: &mut Client) {
+    // The old schema must still reject NULL in the removed column, immediately
+    let error = old_db
+        .simple_query("INSERT INTO users (id, email) VALUES (2, NULL)")
+        .unwrap_err();
+    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
+
+    // The new schema doesn't have the column. A user without a profile can't be
+    // committed as the column would be left empty for the old schema
+    let error = new_db
+        .simple_query("INSERT INTO users (id) VALUES (3)")
+        .unwrap_err();
+    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
+    let count: i64 = old_db
+        .query_one("SELECT COUNT(*) FROM users WHERE id = 3", &[])
+        .unwrap()
+        .get(0);
+    assert_eq!(0, count);
+
+    // Within a transaction, the user can be inserted before the profile it takes its
+    // email from, as the check is made when the transaction commits
+    new_db
+        .batch_execute(
+            "
+            BEGIN;
+            INSERT INTO users (id) VALUES (4);
+            INSERT INTO profiles (user_id, email) VALUES (4, 'four@example.com');
+            COMMIT;
+            ",
+        )
+        .unwrap();
+    let email: String = old_db
+        .query_one("SELECT email FROM users WHERE id = 4", &[])
+        .unwrap()
+        .get("email");
+    assert_eq!("four@example.com", email);
+
+    // A transaction which leaves the column empty fails when committing
+    let error = new_db
+        .batch_execute(
+            "
+            BEGIN;
+            INSERT INTO users (id) VALUES (5);
+            COMMIT;
+            ",
+        )
+        .unwrap_err();
+    assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
+    let count: i64 = old_db
+        .query_one("SELECT COUNT(*) FROM users WHERE id = 5", &[])
+        .unwrap()
+        .get(0);
+    assert_eq!(0, count);
+
+    // Writes to the source table in the new schema fill in the removed column
+    new_db
+        .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
+        .unwrap();
+    let email: String = old_db
+        .query_one("SELECT email FROM users WHERE id = 1", &[])
+        .unwrap()
+        .get("email");
+    assert_eq!("test2@example.com", email);
+}
+
+// Asserts that NOT NULL is back on users.email once the migration has been aborted
+fn assert_email_not_null(db: &mut Client) {
+    let is_nullable: String = db
+        .query_one(
+            "
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'email'
+            ",
+            &[],
+        )
+        .unwrap()
+        .get("is_nullable");
+    assert_eq!("NO", is_nullable);
 }
 
 #[test]
@@ -623,36 +709,8 @@ fn remove_column_not_null_with_complex_down() {
             .unwrap();
     });
 
-    test.intermediate(|old_db, new_db| {
-        // The old schema must still reject NULL in the removed column
-        let result = old_db.simple_query("INSERT INTO users (id, email) VALUES (2, NULL)");
-        assert!(
-            result.is_err(),
-            "expected NULL email to be rejected in old schema"
-        );
-
-        // The new schema doesn't have the column and must be able to insert a user
-        // without a matching profile, which leaves the removed column NULL
-        new_db
-            .simple_query("INSERT INTO users (id) VALUES (3)")
-            .unwrap();
-
-        // Remove the row again as an abort reinstates NOT NULL, which the NULL email
-        // left behind by the insert would otherwise block
-        new_db
-            .simple_query("DELETE FROM users WHERE id = 3")
-            .unwrap();
-
-        // Writes to the source table in the new schema fill in the removed column
-        new_db
-            .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
-            .unwrap();
-        let email: String = old_db
-            .query_one("SELECT email FROM users WHERE id = 1", &[])
-            .unwrap()
-            .get("email");
-        assert_eq!("test2@example.com", email);
-    });
+    test.intermediate(check_not_null_column_with_complex_down);
+    test.after_abort(assert_email_not_null);
 
     test.run();
 }
@@ -727,36 +785,8 @@ fn remove_column_not_null_from_earlier_in_flight_alter_with_complex_down() {
             .unwrap();
     });
 
-    test.intermediate(|old_db, new_db| {
-        // The old schema must still reject NULL in the removed column
-        let result = old_db.simple_query("INSERT INTO users (id, email) VALUES (2, NULL)");
-        assert!(
-            result.is_err(),
-            "expected NULL email to be rejected in old schema"
-        );
-
-        // The new schema doesn't have the column and must be able to insert a user
-        // without a matching profile, which leaves the removed column NULL
-        new_db
-            .simple_query("INSERT INTO users (id) VALUES (3)")
-            .unwrap();
-
-        // Remove the row again as an abort reinstates NOT NULL, which the NULL email
-        // left behind by the insert would otherwise block
-        new_db
-            .simple_query("DELETE FROM users WHERE id = 3")
-            .unwrap();
-
-        // Writes to the source table in the new schema fill in the removed column
-        new_db
-            .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
-            .unwrap();
-        let email: String = old_db
-            .query_one("SELECT email FROM users WHERE id = 1", &[])
-            .unwrap()
-            .get("email");
-        assert_eq!("test2@example.com", email);
-    });
+    test.intermediate(check_not_null_column_with_complex_down);
+    test.after_abort(assert_email_not_null);
 
     test.run();
 }
@@ -829,15 +859,27 @@ fn remove_column_not_null_from_in_flight_add_column_with_complex_down() {
     });
 
     test.intermediate(|old_db, new_db| {
-        // Neither schema has the column, so both must be able to insert users
+        // The old schema doesn't have the column and `up` fills it in
         old_db
             .simple_query("INSERT INTO users (id) VALUES (2)")
             .unwrap();
-        new_db
+
+        // The new schema doesn't have the column either, and must insert a profile to take
+        // the value from before the transaction commits
+        let error = new_db
             .simple_query("INSERT INTO users (id) VALUES (3)")
-            .unwrap();
+            .unwrap_err();
+        assert_eq!(Some(&SqlState::NOT_NULL_VIOLATION), error.code());
+
         new_db
-            .simple_query("DELETE FROM users WHERE id IN (2, 3)")
+            .batch_execute(
+                "
+                BEGIN;
+                INSERT INTO users (id) VALUES (4);
+                INSERT INTO profiles (user_id, email) VALUES (4, 'four@example.com');
+                COMMIT;
+                ",
+            )
             .unwrap();
     });
 

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -562,3 +562,201 @@ fn remove_column_with_long_names() {
 
     test.run();
 }
+
+#[test]
+fn remove_column_not_null_with_complex_down() {
+    let mut test = Test::new("Remove NOT NULL column with complex down");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+            nullable = false
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["user_id"]
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    test.second_migration(
+        r#"
+        name = "remove_users_email_column"
+
+        [[actions]]
+        type = "remove_column"
+        table = "users"
+        column = "email"
+
+            [actions.down]
+            table = "profiles"
+            value = "profiles.email"
+            where = "users.id = profiles.user_id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, email) VALUES (1, 'test@example.com')")
+            .unwrap();
+        db.simple_query("INSERT INTO profiles (user_id, email) VALUES (1, 'test@example.com')")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // The old schema must still reject NULL in the removed column
+        let result = old_db.simple_query("INSERT INTO users (id, email) VALUES (2, NULL)");
+        assert!(
+            result.is_err(),
+            "expected NULL email to be rejected in old schema"
+        );
+
+        // The new schema doesn't have the column and must be able to insert a user
+        // without a matching profile, which leaves the removed column NULL
+        new_db
+            .simple_query("INSERT INTO users (id) VALUES (3)")
+            .unwrap();
+
+        // Remove the row again as an abort reinstates NOT NULL, which the NULL email
+        // left behind by the insert would otherwise block
+        new_db
+            .simple_query("DELETE FROM users WHERE id = 3")
+            .unwrap();
+
+        // Writes to the source table in the new schema fill in the removed column
+        new_db
+            .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
+            .unwrap();
+        let email: String = old_db
+            .query_one("SELECT email FROM users WHERE id = 1", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!("test2@example.com", email);
+    });
+
+    test.run();
+}
+
+#[test]
+fn remove_column_not_null_from_earlier_in_flight_alter_with_complex_down() {
+    let mut test = Test::new("Remove NOT NULL column altered earlier in the batch, complex down");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+            nullable = false
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["user_id"]
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    // The column is altered first, so remove_column sees it backed by the nullable
+    // temporary column rather than the NOT NULL real one
+    test.second_migration(
+        r#"
+        name = "change_default_then_remove_users_email_column"
+
+        [[actions]]
+        type = "alter_column"
+        table = "users"
+        column = "email"
+
+            [actions.changes]
+            default = "'unknown@example.com'"
+
+        [[actions]]
+        type = "remove_column"
+        table = "users"
+        column = "email"
+
+            [actions.down]
+            table = "profiles"
+            value = "profiles.email"
+            where = "users.id = profiles.user_id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id, email) VALUES (1, 'test@example.com')")
+            .unwrap();
+        db.simple_query("INSERT INTO profiles (user_id, email) VALUES (1, 'test@example.com')")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // The old schema must still reject NULL in the removed column
+        let result = old_db.simple_query("INSERT INTO users (id, email) VALUES (2, NULL)");
+        assert!(
+            result.is_err(),
+            "expected NULL email to be rejected in old schema"
+        );
+
+        // The new schema doesn't have the column and must be able to insert a user
+        // without a matching profile, which leaves the removed column NULL
+        new_db
+            .simple_query("INSERT INTO users (id) VALUES (3)")
+            .unwrap();
+
+        // Remove the row again as an abort reinstates NOT NULL, which the NULL email
+        // left behind by the insert would otherwise block
+        new_db
+            .simple_query("DELETE FROM users WHERE id = 3")
+            .unwrap();
+
+        // Writes to the source table in the new schema fill in the removed column
+        new_db
+            .simple_query("UPDATE profiles SET email = 'test2@example.com' WHERE user_id = 1")
+            .unwrap();
+        let email: String = old_db
+            .query_one("SELECT email FROM users WHERE id = 1", &[])
+            .unwrap()
+            .get("email");
+        assert_eq!("test2@example.com", email);
+    });
+
+    test.run();
+}

--- a/tests/remove_column.rs
+++ b/tests/remove_column.rs
@@ -760,3 +760,86 @@ fn remove_column_not_null_from_earlier_in_flight_alter_with_complex_down() {
 
     test.run();
 }
+
+#[test]
+fn remove_column_not_null_from_in_flight_add_column_with_complex_down() {
+    let mut test = Test::new("Remove NOT NULL column added earlier in the batch, complex down");
+
+    test.first_migration(
+        r#"
+        name = "create_tables"
+
+        [[actions]]
+        type = "create_table"
+        name = "users"
+        primary_key = ["id"]
+
+            [[actions.columns]]
+            name = "id"
+            type = "INTEGER"
+
+        [[actions]]
+        type = "create_table"
+        name = "profiles"
+        primary_key = ["user_id"]
+
+            [[actions.columns]]
+            name = "user_id"
+            type = "INTEGER"
+
+            [[actions.columns]]
+            name = "email"
+            type = "TEXT"
+        "#,
+    );
+
+    // The column only exists as the temporary column of add_column, so there is no
+    // real column for remove_column to lift NOT NULL from or to reinstate it on
+    test.second_migration(
+        r#"
+        name = "add_then_remove_users_email_column"
+
+        [[actions]]
+        type = "add_column"
+        table = "users"
+        up = "'added@example.com'"
+
+            [actions.column]
+            name = "email"
+            type = "TEXT"
+            nullable = false
+
+        [[actions]]
+        type = "remove_column"
+        table = "users"
+        column = "email"
+
+            [actions.down]
+            table = "profiles"
+            value = "profiles.email"
+            where = "users.id = profiles.user_id"
+        "#,
+    );
+
+    test.after_first(|db| {
+        db.simple_query("INSERT INTO users (id) VALUES (1)")
+            .unwrap();
+        db.simple_query("INSERT INTO profiles (user_id, email) VALUES (1, 'test@example.com')")
+            .unwrap();
+    });
+
+    test.intermediate(|old_db, new_db| {
+        // Neither schema has the column, so both must be able to insert users
+        old_db
+            .simple_query("INSERT INTO users (id) VALUES (2)")
+            .unwrap();
+        new_db
+            .simple_query("INSERT INTO users (id) VALUES (3)")
+            .unwrap();
+        new_db
+            .simple_query("DELETE FROM users WHERE id IN (2, 3)")
+            .unwrap();
+    });
+
+    test.run();
+}


### PR DESCRIPTION
## Part 1: later actions inherited the nullability of in-flight temporary columns

`ColumnChanges` in `src/schema.rs` only mapped a column name to its backing column. `get_table_by_real_name` then read type, nullability and default from `information_schema.columns` for that backing column. While a migration is in flight, the backing column is the nullable temporary column created by an earlier `alter_column` or `add_column`, with NOT NULL enforced only through a `NOT VALID` check.

A later `alter_column` on the same column in the same batch fell back to that physical nullability and never added its own NOT NULL check, so the constraint was silently lost at complete. `remove_column` with a cross-table `down` read the same value and never lifted NOT NULL for the new schema.

The batch loop shares one `Schema` across all migrations, so two migrations in one batch and two actions in one migration behave identically. Applying one migration at a time hid the bug.

**Fix.** `ColumnChanges` records the declared `data_type`, `nullable` and `default`. Declared attributes win. Anything not declared is inherited from the column the chain of backing columns started from, which carries the real NOT NULL, rather than from the temporary column. `Schema::backing_columns` exposes the chain, and `remove_column` lifts NOT NULL from every column in it, including the temporary checks of earlier actions. `add_column`'s complete tolerates its temporary check having been dropped by such a removal.

## Part 2: `remove_column` abort could fail

With a cross-table `down` on a NOT NULL column, `remove_column` drops NOT NULL and enforced it with a trigger for the old schema only. The new schema had to be allowed to leave the column empty, since a row is often inserted before the row in `down.table` it takes its value from. But a committed NULL made the abort fail when it tried to reinstate NOT NULL, and an abort must never fail.

**Fix.** The check is now two constraint triggers:

- Writes in the old schema still fail immediately, exactly as before.
- Writes in the new schema are checked when the transaction commits, by a `DEFERRABLE INITIALLY DEFERRED` trigger. A row can be inserted and filled in later in the same transaction, but a transaction that leaves it empty fails at commit. No NULL can ever be committed, so abort always succeeds.

Two Postgres details matter here and are verified by the tests:

- A deferred row trigger is handed the row version from when the event was queued, not the current one, so checking `NEW` directly would reject the insert-then-fill case. The deferred trigger looks the row up again by primary key.
- Both triggers use `WHEN` conditions, so no event is queued for old-schema writes or for rows that already have a value. Old-schema bulk writes therefore cost nothing extra. The `WHEN` clauses reference the column, so complete drops the triggers before the column.

Both triggers raise with SQLSTATE `23502` so clients see the same error class as a real NOT NULL violation.

The primary key lookup already used by the backfill is shared via `common::get_primary_key_columns_for_table` and `common::primary_key_match`, handles composite keys, and now fails with a clear error for tables without a primary key instead of panicking. Abort is also idempotent now: re-running it after an interruption no longer fails on an existing constraint.

## Also found and fixed along the way

The reverse trigger of `remove_column` and `add_column` guarded itself with `NOT current_setting('reshape.disable_triggers', TRUE) = 'TRUE'`. In a session that never set that setting the value is NULL, the condition is NULL, and the trigger body never ran. The new-schema insert path with a cross-table `down` was therefore silently inert in fresh sessions. It now uses `IS DISTINCT FROM`.

## Tests

`alter_column`:
- `alter_column_multiple` gains a post-completion NOT NULL assertion.
- `alter_column_keeps_not_null_from_earlier_in_flight_alter`, `alter_column_keeps_not_null_from_in_flight_add_column`.
- `alter_column_requires_primary_key` checks the error for a table without a primary key.

`remove_column`, all with a cross-table `down` on a NOT NULL column: a baseline, one after an in-flight `alter_column`, one after an in-flight `add_column`. Each checks that the old schema rejects NULL immediately with `23502`, that a new-schema insert without a source row fails at commit with `23502` and leaves no row, that insert-then-fill in one transaction succeeds and propagates to the old schema, and that NOT NULL is back after abort. `remove_column_with_long_names` now expects four distinct triggers.

## Not addressed

`Reshape::remove` drops tables but not the standalone trigger functions, so a test that panics mid-migration pollutes later runs until the functions are dropped by hand. Separately, aborting an action whose table doesn't exist, for example after a validation failure, can itself fail. Both are pre-existing.